### PR TITLE
Revert image references for debian workers

### DIFF
--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -244,7 +244,7 @@ func (inflater *apiInflater) getCalculateChecksumWorkflow(diskURI string, daisyP
 				{
 					Disk: compute.Disk{
 						Name:        "disk-${NAME}",
-						SourceImage: "projects/compute-image-import/global/images/family/debian-9-worker",
+						SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 						Type:        "pd-ssd",
 					},
 				},

--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -255,7 +255,7 @@ var (
 	privacyRegex    = regexp.MustCompile(`\[Privacy\->.*?<\-Privacy\]`)
 	privacyTagRegex = regexp.MustCompile(`(\[Privacy\->)|(<\-Privacy\])`)
 
-	debianWorkerRegex = regexp.MustCompile("projects/compute-image-import/global/images/family/debian-\\d+-worker")
+	debianWorkerRegex = regexp.MustCompile("projects/compute-image-tools/global/images/family/debian-\\d+-worker")
 )
 
 // GetSortedOSIDs returns the supported OS identifiers, sorted.

--- a/cli_tools/common/utils/daisyutils/daisy_utils_test.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils_test.go
@@ -279,7 +279,7 @@ func createWorkflowWithCreateDiskImageAndIncludeWorkflow() *daisy.Workflow {
 				},
 				{
 					Disk: compute.Disk{
-						SourceImage: "projects/compute-image-import/global/images/family/debian-9-worker",
+						SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 					},
 				},
 			},

--- a/cli_tools/gce_ovf_export/exporter/instance_disks_exporter.go
+++ b/cli_tools/gce_ovf_export/exporter/instance_disks_exporter.go
@@ -143,7 +143,7 @@ func (ide *instanceDisksExporterImpl) addExportDisksSteps(w *daisy.Workflow, ins
 			"source_disk":                diskPath,
 			"destination":                exportedDiskGCSPath,
 			"format":                     params.DiskExportFormat,
-			"export_instance_disk_image": "projects/compute-image-import/global/images/family/debian-9-worker",
+			"export_instance_disk_image": "projects/compute-image-tools/global/images/family/debian-9-worker",
 			"export_instance_disk_size":  "200",
 			"export_instance_disk_type":  "pd-ssd",
 			"export_network":             params.Network,

--- a/cli_tools/gce_ovf_export/exporter/instance_disks_exporter_test.go
+++ b/cli_tools/gce_ovf_export/exporter/instance_disks_exporter_test.go
@@ -76,7 +76,7 @@ func TestDiskExporter_HappyPath(t *testing.T) {
 	}
 	mockComputeClient.EXPECT().GetProject(project).Return(&compute.Project{Name: project}, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListZones(project).Return([]*compute.Zone{{Id: 0, Name: params.Zone}}, nil).AnyTimes()
-	mockComputeClient.EXPECT().GetImageFromFamily("compute-image-import", "debian-9-worker").Return(&compute.Image{Name: "debian-9-worker"}, nil).AnyTimes()
+	mockComputeClient.EXPECT().GetImageFromFamily("compute-image-tools", "debian-9-worker").Return(&compute.Image{Name: "debian-9-worker"}, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListDisks(project, params.Zone).Return(disks, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListMachineTypes(project, params.Zone).Return([]*compute.MachineType{}, nil).AnyTimes()
 	mockComputeClient.EXPECT().GetMachineType(project, params.Zone, gomock.Any()).Return(&compute.MachineType{Name: "n1-highcpu-4"}, nil).AnyTimes()

--- a/cli_tools/gce_ovf_export/exporter/instance_export_cleaner_test.go
+++ b/cli_tools/gce_ovf_export/exporter/instance_export_cleaner_test.go
@@ -71,7 +71,7 @@ func TestCleaner(t *testing.T) {
 	}
 	mockComputeClient.EXPECT().GetProject(project).Return(&compute.Project{Name: project}, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListZones(project).Return([]*compute.Zone{{Id: 0, Name: params.Zone}}, nil).AnyTimes()
-	mockComputeClient.EXPECT().GetImageFromFamily("compute-image-import", "debian-9-worker").Return(&compute.Image{Name: "debian-9-worker"}, nil).AnyTimes()
+	mockComputeClient.EXPECT().GetImageFromFamily("compute-image-tools", "debian-9-worker").Return(&compute.Image{Name: "debian-9-worker"}, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListDisks(project, params.Zone).Return(disks, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListMachineTypes(project, params.Zone).Return([]*compute.MachineType{}, nil).AnyTimes()
 	mockComputeClient.EXPECT().GetMachineType(project, params.Zone, gomock.Any()).Return(&compute.MachineType{Name: "n1-highcpu-4"}, nil).AnyTimes()

--- a/cli_tools/gce_ovf_export/exporter/instance_export_preparer_test.go
+++ b/cli_tools/gce_ovf_export/exporter/instance_export_preparer_test.go
@@ -69,7 +69,7 @@ func TestPreparer(t *testing.T) {
 	}
 	mockComputeClient.EXPECT().GetProject(project).Return(&compute.Project{Name: project}, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListZones(project).Return([]*compute.Zone{{Id: 0, Name: params.Zone}}, nil).AnyTimes()
-	mockComputeClient.EXPECT().GetImageFromFamily("compute-image-import", "debian-9-worker").Return(&compute.Image{Name: "debian-9-worker"}, nil).AnyTimes()
+	mockComputeClient.EXPECT().GetImageFromFamily("compute-image-tools", "debian-9-worker").Return(&compute.Image{Name: "debian-9-worker"}, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListDisks(project, params.Zone).Return(disks, nil).AnyTimes()
 	mockComputeClient.EXPECT().ListMachineTypes(project, params.Zone).Return([]*compute.MachineType{}, nil).AnyTimes()
 	mockComputeClient.EXPECT().GetMachineType(project, params.Zone, gomock.Any()).Return(&compute.MachineType{Name: "n1-highcpu-4"}, nil).AnyTimes()

--- a/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
+++ b/cli_tools/gce_ovf_import/daisy_utils/data_disk_workflow_updater.go
@@ -79,7 +79,7 @@ func AddDiskImportSteps(w *daisy.Workflow, dataDiskInfos []ovfutils.DiskInfo) {
 			{
 				Disk: compute.Disk{
 					Name:        diskImporterDiskName,
-					SourceImage: "projects/compute-image-import/global/images/family/debian-9-worker",
+					SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
 					Type:        "pd-ssd",
 				},
 				SizeGb: gceMinimumDiskSizeGB,


### PR DESCRIPTION
In #3, we changed references of `compute-image-tools` to `compute-image-import`; the references for the debian worker images need to come from compute-image-tools.

This is currently causing the OVF export test to fail with `can't use image "projects/compute-image-import/global/images/family/debian-9-worker"`


https://oss-prow.knative.dev/view/gs/compute-image-import-prow/logs/compute-image-import-ovf-export-e2e-tests-daily/1516127665080242176