### PR TITLE
Fix Windows-8.1 e2e test failures.

### DIFF
--- a/daisy_workflows/image_import/windows/translate.ps1
+++ b/daisy_workflows/image_import/windows/translate.ps1
@@ -286,7 +286,7 @@ function Install-Packages {
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-balloon -ErrorAction SilentlyContinue
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-driver-pvpanic -ErrorAction SilentlyContinue
     Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-compute-engine-vss -ErrorAction SilentlyContinue
-    if (([System.Environment]::OSVersion.Version) -ge 6.2) {
+    if (([System.Environment]::OSVersion.Version) -ge "6.2") {
       Run-Command 'C:\ProgramData\GooGet\googet.exe' -root 'C:\ProgramData\GooGet' -noconfirm install google-osconfig-agent
     } else {
       Write-Output 'Skipping installation of OS Config agent. Requires Windows 2012 or newer.'
@@ -301,7 +301,9 @@ function Install-32bitPackages {
   & C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\google-compute-engine-powershell.noarch.1.1.1@4.goo
   & C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\certgen-x86.x86_32.1.0.0@2.goo
   & C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install C:\ProgramData\GooGet\components\google-compute-engine-sysprep.noarch.3.10.1@1.goo
-  & C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install -reinstall C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo
+  if (([System.Environment]::OSVersion.Version) -ge "10.0") {
+    & C:\ProgramData\GooGet\googet.exe -root C:\ProgramData\GooGet -noconfirm install -reinstall C:\ProgramData\GooGet\components\google-compute-engine-metadata-scripts-x86.x86_32.4.2.1@1.goo
+  }
   if ($script:install_packages.ToLower() -eq 'true') {
     Write-Output 'Translate: Installing GCE packages...'
     # Install each individually in order to catch individual errors


### PR DESCRIPTION
We install `google-compute-engine-metadata-scripts` to simplify scheduling startup tasks on Windows VMs.

This package creates and schedules a task `GCEStartup` that later reads the value of `windows-startup-script-ps1` stored in metadata.

For some reason, on Windows-10 VMs this task assigned a wrong activation value and therefore is not invoked on startup.

After reinstalling the package this issue is solved. See this [PR](https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1165) for details.

However, it corrupts the activation time of `GCEStartup` on Windows-8.1 VMs. Therefore we need to check the Windows version before reinstalling this package.

One small note, we need to compare the version with a string value instead of a number, otherwise this check will fail for numbers that can be considered as integers, for example, 10.0.