### PR TITLE
CLI Tools: Update ReadMe to fix the github URL

### DIFF
--- a/cli_tools/gce_onestep_image_import/README.md
+++ b/cli_tools/gce_onestep_image_import/README.md
@@ -11,7 +11,7 @@ install the `gce_onestep_image_import` tool, this should place the binary in the
 [Go bin directory](https://golang.org/doc/code.html#GOPATH):
 
 ```
-go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_onestep_image_import
+go get github.com/GoogleCloudPlatform/compute-image-import/cli_tools/gce_onestep_image_import
 ```
 
 ### Flags


### PR DESCRIPTION
Changed the github path to compute-image-import at line#14.