### PR TITLE
OneStepImageImport_e2e_use_debian_ami_for_no_default_network_and_remove_windows_ami_test

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/aws_test_utils.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/aws_test_utils.go
@@ -116,7 +116,7 @@ func getAWSTestArgs() bool {
 	}
 
 	if awsCredFilePath == "" || awsRegion == "" || awsBucket == "" ||
-		ubuntuAMIID == "" || debianAMIID == "" || ubuntuVMDKFilePath == "" ||
+		ubuntuAMIID == "" || ubuntuVMDKFilePath == "" ||
 		windowsVMDKFilePath == "" {
 		return false
 	}

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/aws_test_utils.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/aws_test_utils.go
@@ -36,14 +36,14 @@ const (
 	awsRegionFlag   = "aws_region"
 	awsBucketFlag   = "aws_bucket"
 	ubuntuAMIFlag   = "ubuntu_ami_id"
-	windowsAMIFlag  = "windows_ami_id"
+	debianAMIFlag   = "debian_ami_id"
 	ubuntuVMDKFlag  = "ubuntu_vmdk"
 	windowsVMDKFlag = "windows_vmdk"
 )
 
 var (
 	awsCredFilePath, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, awsRegion, awsBucket,
-	ubuntuAMIID, windowsAMIID, ubuntuVMDKFilePath, windowsVMDKFilePath string
+	ubuntuAMIID, debianAMIID, ubuntuVMDKFilePath, windowsVMDKFilePath string
 )
 
 type onestepImportAWSTestProperties struct {
@@ -104,8 +104,8 @@ func getAWSTestArgs() bool {
 			awsBucket = val
 		case ubuntuAMIFlag:
 			ubuntuAMIID = val
-		case windowsAMIFlag:
-			windowsAMIID = val
+		case debianAMIFlag:
+			debianAMIID = val
 		case ubuntuVMDKFlag:
 			ubuntuVMDKFilePath = val
 		case windowsVMDKFlag:
@@ -116,7 +116,7 @@ func getAWSTestArgs() bool {
 	}
 
 	if awsCredFilePath == "" || awsRegion == "" || awsBucket == "" ||
-		ubuntuAMIID == "" || windowsAMIID == "" || ubuntuVMDKFilePath == "" ||
+		ubuntuAMIID == "" || debianAMIID == "" || ubuntuVMDKFilePath == "" ||
 		windowsVMDKFilePath == "" {
 		return false
 	}

--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/onestep_import/onestep_import_test_suite.go
@@ -61,7 +61,7 @@ func OnestepImageImportSuite(
 		onestepImageImportFromAWSUbuntuAMI := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "From AWS Ubuntu-1804 AMI"))
 		onestepImageImportFromAWSUbuntuAMIWithCustomNetwork := junitxml.NewTestCase(
-			testSuiteName, fmt.Sprintf("[%v] %v", testType, "From AWS Ubuntu-1804 AMI with custom network/subnet"))
+			testSuiteName, fmt.Sprintf("[%v] %v", testType, "From AWS Debian-10 AMI with custom network/subnet"))
 		onestepImageImportFromAWSUbuntuVMDK := junitxml.NewTestCase(
 			testSuiteName, fmt.Sprintf("[%v] %v", testType, "From AWS Ubuntu-1804 VMDK"))
 
@@ -75,11 +75,8 @@ func OnestepImageImportSuite(
 	// Only test windows for wrapper to reduce the test time. The aws-related code
 	// logic for windows are exactly the same as for linux, so no need to
 	// duplicate them too much.
-	onestepImageImportFromAWSWindowsAMI := junitxml.NewTestCase(
-		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "From AWS Windows-2019 AMI"))
 	onestepImageImportFromAWSWindowsVMDK := junitxml.NewTestCase(
 		testSuiteName, fmt.Sprintf("[%v] %v", e2e.Wrapper, "From AWS Windows-2019 VMDK"))
-	testsMap[e2e.Wrapper][onestepImageImportFromAWSWindowsAMI] = runOnestepImageImportFromAWSWindowsAMI
 	testsMap[e2e.Wrapper][onestepImageImportFromAWSWindowsVMDK] = runOnestepImageImportFromAWSWindowsVMDK
 
 	// Only test service account scenario for wrapper, till gcloud support it.
@@ -144,8 +141,8 @@ func runOnestepImageImportFromAWSLinuxAMIWithCustomNetwork(ctx context.Context, 
 
 	props := &onestepImportAWSTestProperties{
 		imageName:     imageName,
-		amiID:         ubuntuAMIID,
-		os:            "ubuntu-1804",
+		amiID:         debianAMIID,
+		os:            "debian-10",
 		startupScript: "post_translate_test.sh",
 		skipOSConfig:  "true",
 		network:       "projects/compute-image-test-custom-vpc/global/networks/unrestricted-egress",
@@ -165,21 +162,6 @@ func runOnestepImageImportFromAWSLinuxVMDK(ctx context.Context, testCase *junitx
 		os:                "ubuntu-1804",
 		startupScript:     "post_translate_test.sh",
 		skipOSConfig:      "true",
-	}
-
-	runOnestepImportTest(ctx, props, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testType, logger, testCase)
-}
-
-func runOnestepImageImportFromAWSWindowsAMI(ctx context.Context, testCase *junitxml.TestCase, logger *log.Logger,
-	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
-	imageName := "e2e-test-onestep-image-import" + path.RandString(5)
-
-	props := &onestepImportAWSTestProperties{
-		imageName:     imageName,
-		amiID:         windowsAMIID,
-		os:            "windows-2019",
-		timeout:       "4h",
-		startupScript: "post_translate_test.ps1",
 	}
 
 	runOnestepImportTest(ctx, props, testProjectConfig.TestProjectID, testProjectConfig.TestZone, testType, logger, testCase)


### PR DESCRIPTION
OneStepImageImport_e2e_use_debian_ami_for_no_default_network_and_remove_windows_ami_test

Update OneStepImageImport e2e tests:
- removed aws-windows-ami & add new aws-debian-ami
- changed the aws images IDs & path of cred file to WAW team aws account resources (in this [PR](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1643))

Why we added a new Linux(Debain) test for "no-default-network" test instead of using ubuntu image?
- because ubuntu-ami is already used in another test, and when tests run in parallel, we cannot have 2 active aws export, we have this error "ResourceCountExceeded: You already reached the maximum limit (1) of active export image tasks status code: 400", So we decided to create a new linux AMI image (Debian) for now just to pass the e2e test and then we will think about increasing the quota in AWS if it's doable.

/cc yswe
/assign yswe