### PR TITLE
Add commit hash to description of Debian worker image

### DIFF
--- a/daisy_workflows/image_build/debian/README.md
+++ b/daisy_workflows/image_build/debian/README.md
@@ -2,11 +2,12 @@
 
 ### debian_worker.wf.json
 
-Imports a virtual disk file and converts it into a GCE image resource.
+Build a new Debian worker image for GCE import/export operations.
 This workflow has been tested with Debian 10 and 11.
 
 Variables:
 * `build_tag`: Build tag used to version the image. Default: Current date in format YYYYMMDD.
+* `commit_short_sha`: Git commit hash (SHORT_SHA in Cloud Build) to link the worker build to its commit. Default: ""
 * `family_tag`: Image family name used as a base image. Default: debian-11
 * `image_prefix`: Prefix for the created image. Default: debian-11-worker
 * `source_image`: Source image for Debian worker. Default: projects/debian-cloud/global/images/family/debian-11

--- a/daisy_workflows/image_build/debian/README.md
+++ b/daisy_workflows/image_build/debian/README.md
@@ -7,7 +7,7 @@ This workflow has been tested with Debian 10 and 11.
 
 Variables:
 * `build_tag`: Build tag used to version the image. Default: Current date in format YYYYMMDD.
-* `commit_short_sha`: Git commit hash (SHORT_SHA in Cloud Build) to link the worker build to its commit. Default: ""
+* `commit_sha`: Git commit hash ($COMMIT_SHA in Cloud Build) to link the worker build to its commit. Default: ""
 * `family_tag`: Image family name used as a base image. Default: debian-11
 * `image_prefix`: Prefix for the created image. Default: debian-11-worker
 * `source_image`: Source image for Debian worker. Default: projects/debian-cloud/global/images/family/debian-11

--- a/daisy_workflows/image_build/debian/debian_worker.wf.json
+++ b/daisy_workflows/image_build/debian/debian_worker.wf.json
@@ -5,9 +5,9 @@
       "Value": "${DATE}",
       "Description": "Build tag used to version the image."
     },
-    "commit_short_sha": {
+    "commit_sha": {
       "Value": "",
-      "Description": "Git commit hash (SHORT_SHA in Cloud Build) to link the worker build to its commit."
+      "Description": "Git commit hash ($COMMIT_SHA in Cloud Build) to link the worker build to its commit."
     },
     "family_tag": {
       "Required": true,
@@ -75,7 +75,7 @@
       "CreateImages": [{
         "Name": "${image_prefix}-v${build_tag}",
         "SourceDisk": "disk-worker",
-        "Description": "A ${family_tag} image for import/export tools. Built on commit: ${commit_short_sha}",
+        "Description": "A ${family_tag} image for import/export tools. Built on commit: ${commit_sha}",
         "Family": "${family_tag}",
         "NoCleanup": true,
         "ExactName": true,

--- a/daisy_workflows/image_build/debian/debian_worker.wf.json
+++ b/daisy_workflows/image_build/debian/debian_worker.wf.json
@@ -5,6 +5,10 @@
       "Value": "${DATE}",
       "Description": "Build tag used to version the image."
     },
+    "commit_short_sha": {
+      "Value": "",
+      "Description": "Git commit hash (SHORT_SHA in Cloud Build) to link the worker build to its commit."
+    },
     "family_tag": {
       "Required": true,
       "Value": "debian-11-worker",
@@ -71,7 +75,7 @@
       "CreateImages": [{
         "Name": "${image_prefix}-v${build_tag}",
         "SourceDisk": "disk-worker",
-        "Description": "A ${family_tag} based worker image for import/export tools.",
+        "Description": "A ${family_tag} image for import/export tools. Built on commit: ${commit_short_sha}",
         "Family": "${family_tag}",
         "NoCleanup": true,
         "ExactName": true,

--- a/debian_worker_cloudbuild.yaml
+++ b/debian_worker_cloudbuild.yaml
@@ -22,8 +22,8 @@
 timeout: 4500s
 
 substitutions:
-  _IMAGE_PROJECT: 'debian-worker-ks'
-  _GCS_PATH: 'gs://debian-worker-ks'
+  _IMAGE_PROJECT: 'compute-image-import'
+  _GCS_PATH: 'gs://compute-image-import'
   _DAISY_WORKFLOW: '/workspace/daisy_workflows/image_build/debian/debian_worker.wf.json'
   _DAISY_DOCKER_TAG: 'latest'
 

--- a/debian_worker_cloudbuild.yaml
+++ b/debian_worker_cloudbuild.yaml
@@ -34,6 +34,7 @@ steps:
   args: [
         '-gcs_path=${_GCS_PATH}',
         '-project=${_IMAGE_PROJECT}',
+        '-var:commit_short_sha=$SHORT_SHA',
         '-var:family_tag=debian-10',
         '-var:image_prefix=debian-10-worker',
         '-var:source_image=projects/debian-cloud/global/images/family/debian-10',
@@ -46,6 +47,7 @@ steps:
   args: [
         '-gcs_path=${_GCS_PATH}',
         '-project=${_IMAGE_PROJECT}',
+        '-var:commit_short_sha=$SHORT_SHA',
         '-var:family_tag=debian-11',
         '-var:image_prefix=debian-11-worker',
         '-var:source_image=projects/debian-cloud/global/images/family/debian-11',

--- a/debian_worker_cloudbuild.yaml
+++ b/debian_worker_cloudbuild.yaml
@@ -22,8 +22,8 @@
 timeout: 4500s
 
 substitutions:
-  _IMAGE_PROJECT: 'compute-image-import'
-  _GCS_PATH: 'gs://compute-image-import'
+  _IMAGE_PROJECT: 'debian-worker-ks'
+  _GCS_PATH: 'gs://debian-worker-ks'
   _DAISY_WORKFLOW: '/workspace/daisy_workflows/image_build/debian/debian_worker.wf.json'
   _DAISY_DOCKER_TAG: 'latest'
 
@@ -34,7 +34,7 @@ steps:
   args: [
         '-gcs_path=${_GCS_PATH}',
         '-project=${_IMAGE_PROJECT}',
-        '-var:commit_short_sha=$SHORT_SHA',
+        '-var:commit_sha=$COMMIT_SHA',
         '-var:family_tag=debian-10',
         '-var:image_prefix=debian-10-worker',
         '-var:source_image=projects/debian-cloud/global/images/family/debian-10',
@@ -47,7 +47,7 @@ steps:
   args: [
         '-gcs_path=${_GCS_PATH}',
         '-project=${_IMAGE_PROJECT}',
-        '-var:commit_short_sha=$SHORT_SHA',
+        '-var:commit_sha=$COMMIT_SHA',
         '-var:family_tag=debian-11',
         '-var:image_prefix=debian-11-worker',
         '-var:source_image=projects/debian-cloud/global/images/family/debian-11',


### PR DESCRIPTION
Adding an additional variable to the debian_worker.wf.json to associate a new Debian worker image with a specific commit hash (short sha, 6 hex chars). By default, this value will be empty (e.g. if run manually outside CI).

See example below:

<img width="634" alt="image" src="https://user-images.githubusercontent.com/6935519/174277820-a02ec5db-8b04-4659-81cd-1aceac7371e8.png">

/cc @yswe @MahmoudNada0 
/assign @yswe 
