### PR TITLE
Use Debian 11 worker for rhel import

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker-v20220619",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_byol.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker-v20220619",
+          "SourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20220618",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker-v20220619",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_8_licensed.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-11-worker-v20220619",
+          "SourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20220618",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }


### PR DESCRIPTION
Use new Debian 11 worker from June 18th for rhel import workflows.

/cc @yswe @MahmoudNada0 
/assign @yswe 