### PR TITLE
Fix AWS unit tests.

### DIFF
--- a/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer_test.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/aws_importer_test.go
@@ -471,7 +471,7 @@ func TestTransferFileDownloadToReaderChan(t *testing.T) {
 	awsImporter := getAWSImporter(t, args)
 	awsImporter.transferFileFn = nil
 	getObjectResp.output = &s3.GetObjectOutput{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("file data"))),
+		Body: io.NopCloser(bytes.NewReader([]byte("file data"))),
 	}
 
 	awsImporter.getUploaderFn = func() *uploader {
@@ -488,6 +488,7 @@ func TestTransferFileDownloadToReaderChan(t *testing.T) {
 
 	reader := <-awsImporter.uploader.readerChan
 	io.Copy(writer, reader)
+	writer.Close()
 	assert.Contains(t, output.String(), "file data")
 }
 

--- a/cli_tools/gce_onestep_image_import/onestep_importer/utils_test.go
+++ b/cli_tools/gce_onestep_image_import/onestep_importer/utils_test.go
@@ -82,6 +82,7 @@ func TestUploaderCopiesFile(t *testing.T) {
 	uploader.readerChan <- r
 	close(uploader.readerChan)
 	uploader.Wait()
+	writerCloser.Close()
 	assert.Equal(t, output.String(), data)
 }
 


### PR DESCRIPTION
We have to call Close in the end of unit tests for writers, so they flush their output to their string variables.

/cc @MahmoudNada0 
/assign @MahmoudNada0 