### PR TITLE
ImageImport_drop_rhel_6_e2e_test

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -258,10 +258,6 @@ var basicCases = []*testCase{
 		source:   "projects/compute-image-import-test/global/images/centos-8-3",
 		os:       "centos-8",
 	}, {
-		caseName: "el-rhel-6-10",
-		source:   "projects/compute-image-import-test/global/images/rhel-6-10",
-		os:       "rhel-6",
-	}, {
 		caseName:  "el-rhel-7-uefi",
 		source:    "projects/compute-image-import-test/global/images/linux-uefi-no-guestosfeature-rhel7",
 		os:        "rhel-7",


### PR DESCRIPTION
As agreed, we will keep supporting RHEL-6 but dropping it's e2e test.

/cc yswe
/assign yswe