### PR TITLE
ImageImport_fix_opensuse_module_test

### DIFF
--- a/cli_tools_tests/module/diskinspect/disk_inspect_test.go
+++ b/cli_tools_tests/module/diskinspect/disk_inspect_test.go
@@ -67,7 +67,7 @@ func TestInspectDisk(t *testing.T) {
 		expected *pb.InspectionResults
 	}{
 		{
-			imageURI: "projects/opensuse-cloud/global/images/opensuse-leap-15-3-v20211011",
+			imageURI: "projects/opensuse-cloud/global/images/family/opensuse-leap-15-3",
 			expected: &pb.InspectionResults{
 				OsRelease: &pb.OsRelease{
 					CliFormatted: "opensuse-15",


### PR DESCRIPTION
Fix opensuse module test by adding reference to family instead of full image uri
/cc yswe
/assign yswe