### PR TITLE
Start using N2 instances for SLES import.

### DIFF
--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -63,7 +63,7 @@
             {"Source": "disk-translator"},
             {"Source": "${source_disk}"}
           ],
-          "MachineType": "n1-standard-2",
+          "MachineType": "n2-standard-2",
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "run-translate.sh",

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -68,7 +68,7 @@
             {"Source": "disk-translator"},
             {"Source": "${source_disk}"}
           ],
-          "MachineType": "e2-standard-2",
+          "MachineType": "n2-standard-2",
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "run-translate.sh",


### PR DESCRIPTION
Some SLES tests have started failing since the end of July because of timeouts. SLES import uses E2 instances that can be not optimal for the import processes. The idea is to stay consistent with other Linux distributions and to use N1 instances.

On the other side, as N2 instances provide better performance than N1 we can update the import for SLES to start using N2 and check how it goes. It will be a good starting point before updating machine types for other distributions and tools.