### PR TITLE
Use N1 instances for now due to quotas limitations.

### DIFF
--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -63,7 +63,7 @@
             {"Source": "disk-translator"},
             {"Source": "${source_disk}"}
           ],
-          "MachineType": "n2-standard-2",
+          "MachineType": "n1-standard-2",
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "run-translate.sh",

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -68,7 +68,7 @@
             {"Source": "disk-translator"},
             {"Source": "${source_disk}"}
           ],
-          "MachineType": "n2-standard-2",
+          "MachineType": "n1-standard-2",
           "Metadata": {
             "files_gcs_dir": "${SOURCESPATH}/import_files",
             "script": "run-translate.sh",


### PR DESCRIPTION
Using N2 instances in import tests leads to E2E tests crashes due to quota limits. As we are going to create a release soon, the migration to N2 will be done in the context of a different task.

/cc @MahmoudNada0 
/assign @MahmoudNada0 