### PR TITLE
Allow SUSE import to proceed when /etc/resolv.conf is immutable

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -183,12 +183,7 @@ checks = [
 def DistroSpecific(spec: TranslateSpec):
   g = spec.g
   el_release = spec.el_release
-  # This must be performed prior to making network calls from the guest.
-  # Otherwise, if /etc/resolv.conf is present, and has an immutable attribute,
-  # guestfs will fail with:
-  #
-  #   rename: /sysroot/etc/resolv.conf to
-  #     /sysroot/etc/i9r7obu6: Operation not permitted
+
   utils.common.ClearEtcResolv(g)
 
   # Some imported images haven't contained `/etc/yum.repos.d`.

--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -329,6 +329,9 @@ def translate():
 
   pkgs = release.gce_packages if include_gce_packages else []
 
+  # Remove the immutable attr on the /etc/resolv.conf file if exist
+  utils.common.ClearEtcResolv(g)
+
   if subscription_model == 'gce':
     logging.info('Converting to on-demand')
     migrate.migrate(

--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -329,7 +329,6 @@ def translate():
 
   pkgs = release.gce_packages if include_gce_packages else []
 
-  # Remove the immutable attr on the /etc/resolv.conf file if exist
   utils.common.ClearEtcResolv(g)
 
   if subscription_model == 'gce':

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -150,6 +150,10 @@ def ClearEtcResolv(g):
 def _ClearImmutableAttr(g, fname):
   """Clears the immutable attr on the file associated with fname.
 
+  This function must be called prior to making network calls from the guest.
+  Otherwise, if /etc/resolv.conf is present, and has an immutable attribute,
+  guestfs will fail with the "Operation not permitted" error.
+
   Args:
     g (guestfs.GuestFS): A mounted GuestFS instance.
     fname (str): File to have its immutable attr cleared.

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -138,12 +138,12 @@ def Execute(cmd, cwd=None, capture_output=False, env=None, raise_errors=True):
 
 
 def ClearEtcResolv(g):
-  """Clear /etc/resolv.conf to allow DNS settings to come from GCP's DHCP 
+  """Clear /etc/resolv.conf to allow DNS settings to come from GCP's DHCP
     server.
 
     This function must be called prior to making network calls from the guest.
     Otherwise, if /etc/resolv.conf is present, and has an immutable attribute,
-    guestfs will fail with this error `rename: /sysroot/etc/resolv.conf to 
+    guestfs will fail with an error like  `rename: /sysroot/etc/resolv.conf to
     /sysroot/etc/i9r7obu6: Operation not permitted`.
 
   Args:

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -138,7 +138,13 @@ def Execute(cmd, cwd=None, capture_output=False, env=None, raise_errors=True):
 
 
 def ClearEtcResolv(g):
-  """Clear /etc/resolv.conf to allow DNS settings to come from GCP's DHCP server.
+  """Clear /etc/resolv.conf to allow DNS settings to come from GCP's DHCP 
+    server.
+
+    This function must be called prior to making network calls from the guest.
+    Otherwise, if /etc/resolv.conf is present, and has an immutable attribute,
+    guestfs will fail with this error `rename: /sysroot/etc/resolv.conf to 
+    /sysroot/etc/i9r7obu6: Operation not permitted`.
 
   Args:
     g (guestfs.GuestFS): A mounted GuestFS instance.
@@ -149,10 +155,6 @@ def ClearEtcResolv(g):
 
 def _ClearImmutableAttr(g, fname):
   """Clears the immutable attr on the file associated with fname.
-
-  This function must be called prior to making network calls from the guest.
-  Otherwise, if /etc/resolv.conf is present, and has an immutable attribute,
-  guestfs will fail with the "Operation not permitted" error.
 
   Args:
     g (guestfs.GuestFS): A mounted GuestFS instance.


### PR DESCRIPTION
Allow SUSE import to proceed when /etc/resolv.conf is immutable

/cc yswe
/assign yswe