### PR TITLE
Attach disks to the worker after it is created.

### DIFF
--- a/cli_tools_tests/e2e/gce_ovf_import/scripts/ovf_import_test_3_disks.sh
+++ b/cli_tools_tests/e2e/gce_ovf_import/scripts/ovf_import_test_3_disks.sh
@@ -206,11 +206,11 @@ function check_package_install {
 }
 
 function check_data_disk_content {
-  if [[ $(< /mnt/b/test_sdb.txt) != "on_sdb" ]]; then
-      fail "/mnt/b/test_sdb.txt not found or content doesn't match."
+  if [[ $(< ${FILE1_PATH}) != "${FILE1_CONTENT}" ]]; then
+      fail "${FILE1_PATH} not found or content doesn't match."
   fi
-  if [[ $(< /mnt/c/test_sdc.txt) != "on_sdc" ]]; then
-      fail "/mnt/c/test_sdc.txt not found or content doesn't match."
+  if [[ $(< ${FILE2_PATH}) != "${FILE2_CONTENT}" ]]; then
+      fail "${FILE2_PATH} not found or content doesn't match."
   fi
 }
 

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_import_e2e_common.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_import_e2e_common.go
@@ -155,13 +155,20 @@ func GetProject(props *OvfImportTestProperties, testProjectConfig *testconfig.Pr
 
 // LoadScriptContent loads script content from local file system. If it fails,
 // the whole program will exit with an error.
-func LoadScriptContent(scriptPath string, logger *log.Logger) string {
-	scriptContent, err := ioutil.ReadFile(scriptPath)
+func LoadScriptContent(scriptPath string, args map[string]string, logger *log.Logger) string {
+	scriptContentBytes, err := ioutil.ReadFile(scriptPath)
 	if err != nil {
 		logger.Printf("Error loading script `%v`: %v", scriptPath, err)
 		os.Exit(1)
 	}
-	return string(scriptContent)
+
+	scriptContent := string(scriptContentBytes)
+
+	for key, value := range args {
+		scriptContent = strings.ReplaceAll(scriptContent, key, value)
+	}
+
+	return scriptContent
 }
 
 // VerifyInstance verifies that imported instance is matching OvfImportTestProperties.

--- a/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
+++ b/cli_tools_tests/e2e/gce_ovf_import/test_suites/ovf_machine_image_import/ovf_machine_image_import_test_suite.go
@@ -124,21 +124,30 @@ func runOVFMachineImageImportDebian3DisksNetworkSettingsName(ctx context.Context
 	testProjectConfig *testconfig.Project, testType e2e.CLITestType) {
 
 	suffix := path.RandString(5)
+	script := ovfimporttestsuite.LoadScriptContent(
+		"scripts/ovf_import_test_3_disks.sh",
+		map[string]string{
+			"${FILE1_PATH}":    "/mnt/b/test_sdb.txt",
+			"${FILE2_PATH}":    "/mnt/c/test_sdc.txt",
+			"${FILE1_CONTENT}": "on_sdb",
+			"${FILE2_CONTENT}": "on_sdc",
+		},
+		logger,
+	)
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-machine-image-ubuntu-3-disks-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
-			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-				"scripts/ovf_import_test_3_disks.sh", logger),
-			Zone:                  testProjectConfig.TestZone,
-			ExpectedStartupOutput: "All tests passed!",
-			FailureMatches:        []string{"TestFailed:"},
-			SourceURI:             fmt.Sprintf("gs://%v/ova/debian-11-three-disks.ova", ovaBucket),
-			Os:                    "debian-11",
-			InstanceMetadata:      skipOSConfigMetadata,
-			MachineType:           "n1-standard-4",
-			Network:               fmt.Sprintf("%v-vpc-1", testProjectConfig.TestProjectID),
-			Subnet:                fmt.Sprintf("%v-subnet-1", testProjectConfig.TestProjectID),
-			Tags:                  []string{"tag1", "tag2", "tag3"},
+			VerificationStartupScript: script,
+			Zone:                      testProjectConfig.TestZone,
+			ExpectedStartupOutput:     "All tests passed!",
+			FailureMatches:            []string{"TestFailed:"},
+			SourceURI:                 fmt.Sprintf("gs://%v/ova/debian-11-three-disks.ova", ovaBucket),
+			Os:                        "debian-11",
+			InstanceMetadata:          skipOSConfigMetadata,
+			MachineType:               "n1-standard-4",
+			Network:                   fmt.Sprintf("%v-vpc-1", testProjectConfig.TestProjectID),
+			Subnet:                    fmt.Sprintf("%v-subnet-1", testProjectConfig.TestProjectID),
+			Tags:                      []string{"tag1", "tag2", "tag3"},
 		},
 	}
 
@@ -153,7 +162,7 @@ func runOVFMachineImageImportWindows2012R2TwoDisksNetworkSettingsPath(ctx contex
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-machine-image-w2k12-r2-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-			"scripts/ovf_import_test_windows_two_disks.ps1", logger),
+			"scripts/ovf_import_test_windows_two_disks.ps1", map[string]string{}, logger),
 			Zone:                  testProjectConfig.TestZone,
 			ExpectedStartupOutput: "All Tests Passed",
 			FailureMatches:        []string{"Test Failed:"},
@@ -178,7 +187,7 @@ func runOVFMachineImageImportCentos74StorageLocation(ctx context.Context, testCa
 		storageLocation:  "asia-northeast1",
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
 			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+				"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                  "asia-northeast1-a",
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
@@ -197,7 +206,7 @@ func runOVFMachineImageImportDebian10WithBootDiskSpanMultiplePhysicalDisks(ctx c
 		machineImageName: fmt.Sprintf("test-gmi-debian10-boot-disk-spans-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
 			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+				"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                  "us-west1-c",
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
@@ -217,7 +226,7 @@ func runOVFMachineImageImportUbuntu18WithBootDiskSpanMultiplePhysicalDisksWithLV
 		machineImageName: fmt.Sprintf("test-gmi-ubuntu18-lvm-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{
 			VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-				"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+				"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                  "us-west1-c",
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
@@ -240,7 +249,7 @@ func runMachineImageImportDisabledDefaultServiceAccountSuccessTest(ctx context.C
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-without-service-account-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                   "europe-west1-c",
 			ExpectedStartupOutput:  "All tests passed!",
 			FailureMatches:         []string{"FAILED:", "TestFailed:"},
@@ -267,7 +276,7 @@ func runMachineImageImportOSDefaultServiceAccountWithMissingPermissionsSuccessTe
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-missing-cse-permissions-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                   "us-west1-c",
 			ExpectedStartupOutput:  "All tests passed!",
 			FailureMatches:         []string{"FAILED:", "TestFailed:"},
@@ -293,7 +302,7 @@ func runMachineImageImportWithDisabledDefaultServiceAccountFailTest(ctx context.
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-missing-permn-on-default-csa-fail-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                  testProjectConfig.TestZone,
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
@@ -317,7 +326,7 @@ func runMachineImageImportDefaultServiceAccountWithMissingPermissionsFailTest(ct
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-insufficient-perm-default-csa-fail-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                  testProjectConfig.TestZone,
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},
@@ -341,7 +350,7 @@ func runMachineImageImportDefaultServiceAccountCustomAccessScope(ctx context.Con
 	props := &ovfMachineImageImportTestProperties{
 		machineImageName: fmt.Sprintf("test-custom-sc-default-sa-%v", suffix),
 		OvfImportTestProperties: ovfimporttestsuite.OvfImportTestProperties{VerificationStartupScript: ovfimporttestsuite.LoadScriptContent(
-			"daisy_integration_tests/scripts/post_translate_test.sh", logger),
+			"daisy_integration_tests/scripts/post_translate_test.sh", map[string]string{}, logger),
 			Zone:                  "asia-southeast1-c",
 			ExpectedStartupOutput: "All tests passed!",
 			FailureMatches:        []string{"FAILED:", "TestFailed:"},

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -32,6 +32,10 @@
     "compute_service_account": {
       "Value": "default",
       "Description": "Service account that will be used by the created worker instance"
+    },
+    "input_disks_count": {
+      "Value": "1",
+      "Description": "The number of disks on the input VM (always 1 for images import)."
     }
   },
   "Sources": {
@@ -45,8 +49,7 @@
         {
           "Name": "inst-translator",
           "Disks": [
-            {"Source": "${translator_disk}"},
-            {"Source": "${imported_disk}"}
+            {"Source": "${translator_disk}"}
           ],
           "MachineType": "n1-standard-2",
           "Metadata": {
@@ -56,7 +59,8 @@
             "prefix": "Translate",
             "el_release": "${el_release}",
             "install_gce_packages": "${install_gce_packages}",
-            "use_rhel_gce_license": "${use_rhel_gce_license}"
+            "use_rhel_gce_license": "${use_rhel_gce_license}",
+            "input_disks_count": "${input_disks_count}"
           },
           "networkInterfaces": [
             {
@@ -73,6 +77,24 @@
           ]
         }
       ]
+    },
+    "wait-for-translate-inst-bootstrap": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-translator",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "Status: Starting bootstrap.sh",
+            "FailureMatch": ["TranslateFailed:", "Failed to download GCS path"]
+          }
+        }
+      ]
+    },
+    "attach-input-disk-to-translate-inst": {
+      "AttachDisks": [{
+        "Source": "${imported_disk}",
+        "Instance": "inst-translator"
+      }]
     },
     "wait-for-translator": {
       "WaitForInstancesSignal": [
@@ -96,6 +118,8 @@
   },
   "Dependencies": {
     "wait-for-translator": ["translate-disk-inst"],
-    "delete-instance": ["wait-for-translator"]
+    "wait-for-translate-inst-bootstrap": ["translate-disk-inst"],
+    "attach-input-disk-to-translate-inst": ["wait-for-translate-inst-bootstrap"],
+    "delete-instance": ["attach-input-disk-to-translate-inst", "wait-for-translator"]
   }
 }


### PR DESCRIPTION
Import / Export tools are built on the assumption that worker disks of
Linux workers will always receive the name `/dev/sda`. It worked well up
to Debian-10 workers. Since Debian-11 this assumption has stopped
working and the names are assigned quite randomly. It leads to the cases
when the worker disk receives the name `/dev/sdb` that breaks the
behaviour of our tools.

This commit updates RHEL workflows (where we already use Debian-11
workers) in the way that input disks are attached after a worker
instance is created, so the worker disk of this instance will always
receive the name `/dev/sda`.

The solution is temporary, in the future we will implement
auto-detection logic for worker disks.

/assign @MahmoudNada0
/cc @MahmoudNada0
/hold