### PR TITLE
ImageImport_attach_disks_to_inspection_worker_instance_after_its_created

### DIFF
--- a/daisy_workflows/image_import/inspection/README.md
+++ b/daisy_workflows/image_import/inspection/README.md
@@ -38,7 +38,7 @@ System-derived dependencies:
 
 ```shell script
 pip3 install .
-boot-inspect /images/ubuntu-16.04-server-cloudimg-amd64-disk1.vmdk 
+boot-inspect --disk_file=/images/ubuntu-16.04-server-cloudimg-amd64-disk1.vmdk
 {
     "device": "/images/ubuntu-16.04-server-cloudimg-amd64-disk1.vmdk",
     "os": {

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -87,7 +87,7 @@
         {
           "Source": "${pd_uri}",
           "Instance": "run-inspection"
-        }  
+        }
       ]
     },
     "cleanup": {

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -23,7 +23,8 @@
     "daisy-shim.sh": "daisy-shim.sh",
     "boot_inspect/src": "../inspection/src",
     "boot_inspect/setup.py": "../inspection/setup.py",
-    "compute_image_tools_proto": "../../../proto/py"
+    "compute_image_tools_proto": "../../../proto/py",
+    "boot_inspect/src/utils": "../../linux_common/utils"
   },
   "Steps": {
     "run-inspection": {
@@ -35,11 +36,8 @@
               "AutoDelete": true,
               "boot": true,
               "initializeParams": {
-                "sourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker"
+                "sourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20220706"
               }
-            },
-            {
-              "Source": "${pd_uri}"
             }
           ],
           "MachineType": "n1-standard-4",
@@ -59,6 +57,18 @@
         }
       ]
     },
+    "wait-for-inspection-start": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "run-inspection",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "Status: inspection started.",
+            "FailureMatch": ["Failed:", "WARNING Failed to download metadata script", "Failed to download GCS path"]
+          }
+        }
+      ]
+    },
     "wait-for-signal": {
       "WaitForInstancesSignal": [
         {
@@ -70,6 +80,14 @@
             "StatusMatch": "Status:"
           }
         }
+      ]
+    },
+    "attach-input-disk": {
+      "AttachDisks": [
+        {
+          "Source": "${pd_uri}",
+          "Instance": "run-inspection"
+        }  
       ]
     },
     "cleanup": {
@@ -84,8 +102,14 @@
     "wait-for-signal": [
       "run-inspection"
     ],
+    "wait-for-inspection-start": [
+      "run-inspection"
+    ],
+    "attach-input-disk": [
+      "wait-for-inspection-start"
+    ],
     "cleanup": [
-      "wait-for-signal"
+      "wait-for-signal", "attach-input-disk"
     ]
   }
 }

--- a/daisy_workflows/image_import/inspection/daisy-shim.sh
+++ b/daisy_workflows/image_import/inspection/daisy-shim.sh
@@ -29,7 +29,7 @@ mkdir -p "$ROOT" && cd "$ROOT"
 gsutil cp -R "$SOURCE/*" .
 pip3 install ./compute_image_tools_proto ./boot_inspect
 
-if boot-inspect --format=daisy /dev/sdb; then
+if boot-inspect --format=daisy --device=/dev/sdb; then
   echo "Success:"
 else
   echo "Failed:"

--- a/daisy_workflows/image_import/inspection/daisy-shim.sh
+++ b/daisy_workflows/image_import/inspection/daisy-shim.sh
@@ -18,6 +18,9 @@
 #     metadata variable.
 #  2. Installs the disk inspection library.
 #  3. Runs disk inspection against /dev/sdb
+
+echo “Status: inspection started.”
+
 set -eufx -o pipefail
 
 ROOT="/tmp/build-root-$RANDOM"

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
@@ -44,6 +44,7 @@ def _output_daisy(results: inspect_pb2.InspectionResults):
 def _output_human(results: inspect_pb2.InspectionResults):
   print(MessageToJson(results, indent=4))
 
+
 def wiat_for_boot_disk():
   success = False
   attached_disks = []

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
@@ -64,15 +64,16 @@ def wait_for_device(device):
 
     attached_disks = diskutils.get_physical_drives()
 
-    # attached_disks include the worker disk
-    if len(attached_disks) >= 2 and device in attached_disks:
+    if device in attached_disks:
       success = True
       break
   if not success:
-    msg = ("Input disk was not attached within the expected timeout")
+    msg = ("Input disk '{}' was not attached within "
+           "the expected timeout").format(device)
     raise RuntimeError(msg)
   else:
-    print("Input disk is attached successfully to the worker instance")
+    print("Input disk '{}' is attached successfully to "
+          "the worker instance".format(device))
 
 
 def main():

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
@@ -51,7 +51,7 @@ def wiat_for_boot_disk():
     time.sleep(i * 10)
 
     attached_disks = diskutils.get_physical_drives()
-    
+
     # attached_disks include the worker disk
     if len(attached_disks) == 2:
       success = True
@@ -61,6 +61,7 @@ def wiat_for_boot_disk():
     raise RuntimeError(msg)
   else:
     print("Input disk is attached successfully to the worker instance")
+
 
 def main():
   wiat_for_boot_disk()

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
@@ -15,12 +15,14 @@
 """Perform inspection, and print results to stdout."""
 import argparse
 import base64
+import time
 
 from boot_inspect import inspection
 from compute_image_tools_proto import inspect_pb2
 from google.protobuf import text_format
 from google.protobuf.json_format import MessageToJson
 import guestfs
+import utils.diskutils as diskutils
 
 
 def _daisy_kv(key: str, value: str):
@@ -42,8 +44,27 @@ def _output_daisy(results: inspect_pb2.InspectionResults):
 def _output_human(results: inspect_pb2.InspectionResults):
   print(MessageToJson(results, indent=4))
 
+def wiat_for_boot_disk():
+  success = False
+  attached_disks = []
+  for i in range(4):
+    time.sleep(i * 10)
+
+    attached_disks = diskutils.get_physical_drives()
+    
+    # attached_disks include the worker disk
+    if len(attached_disks) == 2:
+      success = True
+      break
+  if not success:
+    msg = ("Input disk was not attached within the expected timeout")
+    raise RuntimeError(msg)
+  else:
+    print("Input disk is attached successfully to the worker instance")
 
 def main():
+  wiat_for_boot_disk()
+
   format_options_and_help = {
     'json': 'JSON without newlines. Suitable for consumption by '
             'another program.',

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
@@ -16,8 +16,8 @@
 import argparse
 import base64
 import os
-import time
 import sys
+import time
 
 from boot_inspect import inspection
 from compute_image_tools_proto import inspect_pb2
@@ -103,10 +103,10 @@ def main():
   )
 
   args = parser.parse_args()
-  if args.device == None and args.disk_file == None:
+  if args.device is None and args.disk_file is None:
     print('either --disk_file or --device has to be specified')
     sys.exit(1)
-  if args.device != None and args.disk_file != None:
+  if args.device is not None and args.disk_file is not None:
     print('either --disk_file or --device has to be specified, but not both')
     sys.exit(1)
 
@@ -115,7 +115,7 @@ def main():
   if args.device != None:
     disk_to_inspect = args.device
     wait_for_device(disk_to_inspect)
-  elif file_exists(args.disk_file) == False:
+  elif file_exists(args.disk_file) is False:
     sys.exit(1)
 
   results = inspect_pb2.InspectionResults()

--- a/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
+++ b/daisy_workflows/image_import/inspection/src/boot_inspect/cli.py
@@ -112,7 +112,7 @@ def main():
 
   disk_to_inspect = args.disk_file
 
-  if args.device != None:
+  if args.device is not None:
     disk_to_inspect = args.device
     wait_for_device(disk_to_inspect)
   elif file_exists(args.disk_file) is False:


### PR DESCRIPTION
ImageImport attach disks to inspection worker instance after its created and update inspection worker image.

For more details, read this [description](https://github.com/GoogleCloudPlatform/compute-image-import/pull/56#issue-1351139289).

/assign yswe
/cc yswe