### PR TITLE
Fix E2E SLES tests.

### DIFF
--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -274,6 +274,16 @@ def _install_packages(g: guestfs.GuestFS, pkgs: typing.List[str]):
 
 
 @utils.RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
+def _update_zypper(g: guestfs.GuestFS):
+  """Updates the packages database with Zypper"""
+
+  try:
+    g.command(['zypper', 'update', '-y'])
+  except Exception as e:
+    raise ValueError('Failed to update the packages database: {}'.format(e))
+
+
+@utils.RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def _refresh_zypper(g: guestfs.GuestFS):
   try:
     g.command(['zypper', '--debug', 'refresh'])
@@ -329,6 +339,7 @@ def translate():
 
   pkgs = release.gce_packages if include_gce_packages else []
 
+  _update_zypper(g)
   utils.common.ClearEtcResolv(g)
 
   if subscription_model == 'gce':


### PR DESCRIPTION
SLES images can refer to outdated packages database and then import will fail during installing the package sle-module-public-cloud in the translation step.

Therefore we will update packages database with Zypper before running the translation.

/cc @MahmoudNada0 
/assign @MahmoudNada0 