### PR TITLE
Fix SLES PAYG E2E tests.

### DIFF
--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -339,7 +339,6 @@ def translate():
 
   pkgs = release.gce_packages if include_gce_packages else []
 
-  _update_zypper(g)
   utils.common.ClearEtcResolv(g)
 
   if subscription_model == 'gce':
@@ -351,6 +350,7 @@ def translate():
         post_convert_packages=pkgs
     )
   else:
+    _update_zypper(g)
     _install_product(g, release)
     _refresh_zypper(g)
     _install_packages(g, pkgs)


### PR DESCRIPTION
This is an update to the previous PR https://github.com/GoogleCloudPlatform/compute-image-import/pull/60. Zypper requires an active subscription to install updates. However, if the image is intended to be used on GCE with a PAYG license, then it doesn't need to have a subscritpion. And therefore we can request Zypper updates only for BYOL images.

/cc @MahmoudNada0 
/assign @MahmoudNada0 