### PR TITLE
ImageImport_remove_windows_11_x86_mapping

### DIFF
--- a/cli_tools/common/utils/daisyutils/daisy_utils.go
+++ b/cli_tools/common/utils/daisyutils/daisy_utils.go
@@ -259,7 +259,6 @@ var (
 		// So, we're triggering the same process for windows 11 as windows 10.
 		"windows-11-byol":     "windows-10-x64-byol",
 		"windows-11-x64-byol": "windows-10-x64-byol",
-		"windows-11-x86-byol": "windows-10-x86-byol",
 	}
 
 	privacyRegex    = regexp.MustCompile(`\[Privacy\->.*?<\-Privacy\]`)


### PR DESCRIPTION
ImageImport remove windows-11 x86 mapping as Microsoft now has ended support for 32-bit operating systems

/cc yswe
/assign yswe