### PR TITLE
ImageImport_use_latest_libguestfs_version_from_debian

### DIFF
--- a/daisy_workflows/image_build/debian/debian_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_worker.sh
@@ -31,7 +31,6 @@ APT_PACKAGES="
 debootstrap
 dosfstools
 kpartx
-libguestfs-tools
 parted
 python3-guestfs
 python3-netaddr
@@ -50,6 +49,13 @@ if [[ $? -ne 0 ]]; then
   echo "BuildFailed: Package install failed."
   exit 1
 fi
+
+echo "BuildStatus: Installing libguestfs-tools."
+sed -i 's+http://deb.debian.org/debian bullseye+http://deb.debian.org/debian bookworm+g' /etc/apt/sources.list
+apt-get update
+apt-get -y install libguestfs-tools
+sed -i 's+http://deb.debian.org/debian bookworm+http://deb.debian.org/debian bullseye+g' /etc/apt/sources.list
+apt-get update
 
 echo "BuildStatus: Installing python3 libraries from pip."
 pip3 install -U ${PIP3_PACKAGES}

--- a/daisy_workflows/image_build/debian/debian_worker.sh
+++ b/daisy_workflows/image_build/debian/debian_worker.sh
@@ -50,6 +50,7 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
+# Install latest version of libguestFS available on Debian packages (but still not available on bullseye version)
 echo "BuildStatus: Installing libguestfs-tools."
 sed -i 's+http://deb.debian.org/debian bullseye+http://deb.debian.org/debian bookworm+g' /etc/apt/sources.list
 apt-get update


### PR DESCRIPTION
Adding support for RHEL-9 OS require upgrading libguestFS version to be v1.46.2 or more. For now we'll use latest version available on debian packages of libguesFS which is v.1.48.2

/assign yswe
/cc yswe