### PR TITLE
Use worker image with pre installed protobuf in the inspection workflow

### DIFF
--- a/cli_tools_tests/module/diskinspect/disk_inspect_test.go
+++ b/cli_tools_tests/module/diskinspect/disk_inspect_test.go
@@ -472,8 +472,8 @@ func TestInspectDisk_DontFailWithNoEnabledCloudNatAndNoExternalIP(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	network := "projects/compute-image-test-custom-vpc/global/networks/unrestricted-egress"
-	subnet := fmt.Sprintf("projects/compute-image-test-custom-vpc/regions/%s/subnetworks/unrestricted-egress", region)
+	network := fmt.Sprintf("projects/%s/global/networks/unrestricted-egress", project)
+	subnet := fmt.Sprintf("projects/%s/regions/%s/subnetworks/unrestricted-egress", project, region)
 
 	env := daisyutils.EnvironmentSettings{
 		Project:           project,

--- a/daisy_workflows/image_import/inspection/boot-inspect.wf.json
+++ b/daisy_workflows/image_import/inspection/boot-inspect.wf.json
@@ -36,7 +36,7 @@
               "AutoDelete": true,
               "boot": true,
               "initializeParams": {
-                "sourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker"
+                "sourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20221107"
               }
             }
           ],


### PR DESCRIPTION
Use the new worker image with pre installed protobuf in the inspection workflow & Add new module test to assure that inspection step will not fail if -no_external_ip is used without cloud-NAT

/assign yswe
/cc yswe