### PR TITLE
Dont fail if dracut or depmod commands failed for SUSE and Enterprise Linux

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -293,49 +293,7 @@ def DistroSpecific(spec: TranslateSpec):
       yum_install(g, 'google-cloud-sdk')
     yum_install(g, 'google-compute-engine', 'google-osconfig-agent')
 
-  logging.info('Updating initramfs')
-  for kver in g.ls('/lib/modules'):
-    logging.debug('Updating initramfs for ' + kver)
-    # Although each directory in /lib/modules typically corresponds to a
-    # kernel version  [1], that may not always be true.
-    # kernel-abi-whitelists, for example, creates extra directories in
-    # /lib/modules.
-    #
-    # Skip building initramfs if the directory doesn't look like a
-    # kernel version. Emulates the version matching from depmod [2].
-    #
-    # 1. https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/lib.html
-    # 2. https://kernel.googlesource.com/pub/scm/linux/kernel/git/mmarek/kmod
-    # /+/tip/tools/depmod.c#2537
-    if not re.match(r'^\d+.\d+', kver):
-      logging.debug('/lib/modules/{} doesn\'t look like a kernel directory. '
-                    'Skipping creation of initramfs for it'.format(kver))
-      continue
-
-    # We perform a best-effort attempt to rebuild initramfs; if there's a
-    # failure, continue while giving the user some debug tips. This is
-    # sensible since the existing initramfs may work for booting. Or the
-    # failure may be associated with an older kernel that will never be used.
-    cmds = []
-    if not g.exists(os.path.join('/lib/modules', kver, 'modules.dep')):
-      cmds.append(['depmod', kver])
-    if el_release == '6':
-      # Version 6 doesn't have option --kver
-      cmds.append(['dracut', '-v', '-f', kver])
-    else:
-      cmds.append(['dracut', '--stdlog=1', '-f', '--kver', kver])
-    for cmd in cmds:
-      try:
-        run(g, cmd)
-      except RuntimeError as e:
-        cmd_string = ' '.join(cmd)
-        logging.debug('`{cmd}` error: {err}'.format(cmd=cmd_string, err=e))
-        msg = ('Failed to write initramfs for {kver}. If the image '
-               'fails to boot: Boot the original machine, remove unused '
-               'kernel versions, verify that `{cmd}` runs, re-export '
-               'the disks, and re-import.').format(kver=kver, cmd=cmd_string)
-        logging.info(msg)
-        break
+  utils.RebuildInitramfs(g)
 
   logging.info('Update grub configuration')
   if el_release == '6':

--- a/daisy_workflows/image_import/enterprise_linux/translate.py
+++ b/daisy_workflows/image_import/enterprise_linux/translate.py
@@ -25,7 +25,6 @@ use_rhel_gce_license: True if GCE RHUI package should be installed
 from enum import Enum
 import logging
 import os
-import re
 import time
 
 import guestfs

--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -305,8 +305,6 @@ def _reset_network(g: guestfs.GuestFS):
   ))
 
 
-
-
 def translate():
   """Mounts the disk, runs translation steps, then unmounts the disk."""
   include_gce_packages = utils.GetMetadataAttribute(

--- a/daisy_workflows/image_import/suse/suse_import/translate.py
+++ b/daisy_workflows/image_import/suse/suse_import/translate.py
@@ -305,11 +305,6 @@ def _reset_network(g: guestfs.GuestFS):
   ))
 
 
-def _install_virtio_drivers(g: guestfs.GuestFS):
-  """Rebuilds initramfs to ensure that virtio drivers are present."""
-  logging.info('Installing virtio drivers.')
-  for kernel in g.ls('/lib/modules'):
-    g.command(['dracut', '-v', '-f', '--kver', kernel])
 
 
 def translate():
@@ -343,7 +338,9 @@ def translate():
     _install_product(g, release)
     _refresh_zypper(g)
     _install_packages(g, pkgs)
-  _install_virtio_drivers(g)
+
+    # Rebuilds initramfs to ensure that virtio drivers are present.
+    utils.RebuildInitramfs(g)
   if include_gce_packages:
     logging.info('Enabling google services.')
     for unit in g.ls('/usr/lib/systemd/system/'):

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -246,6 +246,7 @@ def is_rhel6_img(g):
         return True
     return False
 
+
 def RebuildInitramfs(g):
   logging.info('Updating initramfs')
   for kver in g.ls('/lib/modules'):

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -236,6 +236,62 @@ def CommonRoutines(g):
   g.sh("rm -f /etc/ssh/ssh_host_*")
 
 
+def is_rhel6_img(g):
+    if (g.exists('/etc/redhat-release')):
+      # This is a sample string that exist in /etc/redhat-release for RHEL-6:
+      # `Red Hat Enterprise Linux Server release 6.10 (Santiago)`
+      etc_redhat_release_str = str(g.cat('/etc/redhat-release'))
+      if ('Red Hat' in etc_redhat_release_str
+          and 'release 6' in etc_redhat_release_str):
+        return True
+    return False
+
+def RebuildInitramfs(g):
+  logging.info('Updating initramfs')
+  for kver in g.ls('/lib/modules'):
+    logging.debug('Updating initramfs for ' + kver)
+    # Although each directory in /lib/modules typically corresponds to a
+    # kernel version  [1], that may not always be true.
+    # kernel-abi-whitelists, for example, creates extra directories in
+    # /lib/modules.
+    #
+    # Skip building initramfs if the directory doesn't look like a
+    # kernel version. Emulates the version matching from depmod [2].
+    #
+    # 1. https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/lib.html
+    # 2. https://kernel.googlesource.com/pub/scm/linux/kernel/git/mmarek/kmod
+    # /+/tip/tools/depmod.c#2537
+    if not re.match(r'^\d+.\d+', kver):
+      logging.debug('/lib/modules/{} doesn\'t look like a kernel directory. '
+                    'Skipping creation of initramfs for it'.format(kver))
+      continue
+
+    # We perform a best-effort attempt to rebuild initramfs; if there's a
+    # failure, continue while giving the user some debug tips. This is
+    # sensible since the existing initramfs may work for booting. Or the
+    # failure may be associated with an older kernel that will never be used.
+    cmds = []
+    if not g.exists(os.path.join('/lib/modules', kver, 'modules.dep')):
+      cmds.append(['depmod', kver])
+    if is_rhel6_img(g):
+      # Version 6 doesn't have option --kver
+      cmds.append(['dracut', '-v', '-f', kver])
+    else:
+      cmds.append(['dracut', '--stdlog=1', '-f', '--kver', kver])
+    for cmd in cmds:
+      try:
+        run(g, cmd)
+      except RuntimeError as e:
+        cmd_string = ' '.join(cmd)
+        logging.debug('`{cmd}` error: {err}'.format(cmd=cmd_string, err=e))
+        msg = ('Failed to write initramfs for {kver}. If the image '
+               'fails to boot: Boot the original machine, remove unused '
+               'kernel versions, verify that `{cmd}` runs, re-export '
+               'the disks, and re-import.').format(kver=kver, cmd=cmd_string)
+        logging.info(msg)
+        break
+
+
 def RunTranslate(translate_func: typing.Callable,
                  run_with_tracing: bool = True):
   """Run `translate_func`, and communicate success or failure back to Daisy.


### PR DESCRIPTION
Make the Import process don't fail if dracut or depmod failes for any reason in SUSE & run depmod command before dracut command.

/cc @yswe
/cc @michaljankowiak 