### PR TITLE
allow-debian-import-to-proceed-if-the-image-does-not-has-wget-or-curl-installed

### DIFF
--- a/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
+++ b/cli_tools_tests/e2e/gce_image_import_export/test_suites/import/import_tests.go
@@ -123,6 +123,10 @@ var basicCases = []*testCase{
 		caseName: "debian-11",
 		source:   "projects/compute-image-import-test/global/images/debian-11",
 	},
+	{
+		caseName: "debian-11-without-wget-and-curl",
+		source:   "projects/compute-image-import-test/global/images/debian-11-without-wget-and-curl",
+	},
 
 	// Ubuntu
 	{


### PR DESCRIPTION
Allow Debian import (translation step) to proceed without issues when the to-be imported image does not has wget or curl installed.

/cc yswe
/cc @michaljankowiak