### PR TITLE
Use apt-get instead of apt for Debian & Ubuntu translation as it's better to be used in scripts

### DIFF
--- a/daisy_workflows/linux_common/bootstrap.sh
+++ b/daisy_workflows/linux_common/bootstrap.sh
@@ -25,14 +25,14 @@ GetMetadataAttribute() {
 DebianInstallGoogleApiPythonClient() {
     logger -p daemon.info "Status: Installing google-api-python-client"
 
-    apt -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-pip
     pip3 install -U google-api-python-client google-cloud-storage
 }
 
 DebianInstallNetaddrPythonLibrary() {
     logger -p daemon.info "Status: Installing netaddr python module"
 
-    apt -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-netaddr
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -q -y install python3-netaddr
 }
 
 GetAccessToken() {

--- a/daisy_workflows/linux_common/utils/common.py
+++ b/daisy_workflows/linux_common/utils/common.py
@@ -91,12 +91,12 @@ YumInstall.first_run = True
 
 @RetryOnFailure()
 def AptGetInstall(package_list, suite=None):
-  # When `apt update` fails to update a repo, it returns 0.
+  # When `apt-get update` fails to update a repo, it returns 0.
   # This check ensures that we retry running update until we've
   # had one successful install.
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=778357
   if not AptGetInstall.prior_success:
-    Execute(['apt', '-y', 'update'])
+    Execute(['apt-get', '-y', 'update'])
 
   env = os.environ.copy()
   env['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -882,7 +882,7 @@ def install_apt_packages(g, *pkgs):
 
 @RetryOnFailure(stop_after_seconds=5 * 60, initial_delay_seconds=1)
 def update_apt(g):
-  """Runs apt update in a guest.
+  """Runs apt-get update in a guest.
 
   Starting at apt 1.5, release info changes must be confirmed
   explicitly with `--allow-releaseinfo-change`. That flag,
@@ -894,6 +894,6 @@ def update_apt(g):
   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931566
   """
   try:
-    run(g, 'apt update -y')
+    run(g, 'apt-get update -y')
   except RuntimeError:
-    run(g, 'apt update -y --allow-releaseinfo-change')
+    run(g, 'apt-get update -y --allow-releaseinfo-change')


### PR DESCRIPTION
Use apt-get instead of apt for Debian & Ubuntu translation as it's better to be used in scripts and also it cause this: "WARNING: apt does not have a stable CLI interface yet"
/cc @michaljankowiak
/assign @michaljankowiak