### PR TITLE
Removing TCP 80 check

### DIFF
--- a/daisy_workflows/image_import/windows/network.ps1
+++ b/daisy_workflows/image_import/windows/network.ps1
@@ -51,4 +51,3 @@ $interface | Get-DnsClientServerAddress
 # Test connection to packages.cloud.google.com and log results.
 Write-Host 'Testing connection to packages.cloud.google.com:'
 Test-NetConnection -ComputerName packages.cloud.google.com -Port 443
-Test-NetConnection -ComputerName packages.cloud.google.com -Port 80


### PR DESCRIPTION
Removing check for insecure TCP port 80 used for packages.cloud.google.com.