### PR TITLE
Fix typo project name var in latest cloud-build yaml file

### DIFF
--- a/cli_tools_cloudbuild.yaml
+++ b/cli_tools_cloudbuild.yaml
@@ -131,7 +131,7 @@ steps:
   - 'bash'
   - '-c'
   - |
-    GCP_PROJECTS=($_IMAGE_PROJECT_1 _IMAGE_PROJECT_2)
+    GCP_PROJECTS=($_IMAGE_PROJECT_1 $_IMAGE_PROJECT_2)
 
     REGIONS=()
     readarray -t REGIONS < ./supported-regions


### PR DESCRIPTION
/cc @darthmelonder
/assign @darthmelonder