### PR TITLE
Update inflation and image export workflows to use Debian Worker-Images from compute-image-import GCP project

### DIFF
--- a/cli_tools/common/image/importer/api_inflater.go
+++ b/cli_tools/common/image/importer/api_inflater.go
@@ -247,7 +247,7 @@ func (inflater *apiInflater) getCalculateChecksumWorkflow(diskURI string, daisyP
 				{
 					Disk: compute.Disk{
 						Name:        "disk-${NAME}",
-						SourceImage: "projects/compute-image-tools/global/images/family/debian-9-worker",
+						SourceImage: "projects/compute-image-import/global/images/debian-9-worker-v20230926",
 						Type:        "pd-ssd",
 					},
 				},

--- a/daisy_workflows/export/disk_export.wf.json
+++ b/daisy_workflows/export/disk_export.wf.json
@@ -14,7 +14,7 @@
       "Description": "list of GCE licenses to record in the exported image"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {

--- a/daisy_workflows/export/disk_export_ext.wf.json
+++ b/daisy_workflows/export/disk_export_ext.wf.json
@@ -15,7 +15,7 @@
       "Description": "Format to export disk as"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {

--- a/daisy_workflows/export/image_export.wf.json
+++ b/daisy_workflows/export/image_export.wf.json
@@ -16,7 +16,7 @@
       "Description": "list of GCE licenses to record in the exported image"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {

--- a/daisy_workflows/export/image_export_ext.wf.json
+++ b/daisy_workflows/export/image_export_ext.wf.json
@@ -17,7 +17,7 @@
       "Description": "Format to export image as"
     },
     "export_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-10-worker",
+      "Value": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
       "Description": "image to use for the exporter instance"
     },
     "export_instance_disk_size": {

--- a/daisy_workflows/export_metadata/export_metadata.wf.json
+++ b/daisy_workflows/export_metadata/export_metadata.wf.json
@@ -41,7 +41,7 @@
       "CreateDisks": [
         {
           "Name": "disk-exporterprep",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-10-worker",
+          "SourceImage": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
           "Type": "pd-ssd"
         },
         {

--- a/daisy_workflows/image_import/inflate_file.wf.json
+++ b/daisy_workflows/image_import/inflate_file.wf.json
@@ -19,7 +19,7 @@
       "Description": "size of the importer instance disk, additional disk space is unused for the import but a larger size increases PD write speed"
     },
     "import_instance_disk_image": {
-      "Value": "projects/compute-image-tools/global/images/family/debian-9-worker",
+      "Value": "projects/compute-image-import/global/images/debian-9-worker-v20230926",
       "Description": "image to use for the importer instance"
     },
     "disk_name": "imported-disk-${ID}",

--- a/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
+++ b/daisy_workflows/image_import/suse/translate_opensuse_15.wf.json
@@ -49,7 +49,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20221107",
+          "SourceImage": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -53,7 +53,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-import/global/images/debian-9-worker-v20230926",
           "Licenses": ["${license}"],
           "SizeGb": "10",
           "Type": "pd-ssd"

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -36,7 +36,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-import/global/images/debian-10-worker-v20230926",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }


### PR DESCRIPTION
Update inflation and image export workflows to use Debian Worker-Images from compute-image-import GCP project

/cc @darthmelonder
/assign @darthmelonder