### PR TITLE
Reverting worker images for Rhel6 image import

### DIFF
--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-import/global/images/debian-9-worker-v20230926",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20221107",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
+          "SourceImage": "projects/compute-image-import/global/images/debian-9-worker-v20230926",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -43,7 +43,7 @@
       "CreateDisks": [
         {
           "Name": "disk-translator",
-          "SourceImage": "projects/compute-image-import/global/images/debian-11-worker-v20221107",
+          "SourceImage": "projects/compute-image-tools/global/images/family/debian-9-worker",
           "SizeGb": "10",
           "Type": "pd-ssd"
         }


### PR DESCRIPTION
Reverting worker images for rhel6 image import, as upgraded libguestfs seems incompatible.