### PR TITLE
Reapply "Update bucket attributes in order to disable soft delete (#1…

### DIFF
--- a/cli_tools/common/domain/interfaces.go
+++ b/cli_tools/common/domain/interfaces.go
@@ -25,6 +25,7 @@ import (
 // StorageClientInterface represents GCS storage client
 type StorageClientInterface interface {
 	CreateBucket(bucketName string, project string, attrs *storage.BucketAttrs) error
+	UpdateBucket(bucketName string, attrs storage.BucketAttrsToUpdate) error
 	Buckets(projectID string) *storage.BucketIterator
 	GetBucketAttrs(bucket string) (*storage.BucketAttrs, error)
 	GetBucket(bucket string) *storage.BucketHandle

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -73,6 +73,15 @@ func (sc *Client) CreateBucket(
 	return nil
 }
 
+// UpdateBucket updates a GCS bucket
+func (sc *Client) UpdateBucket(
+	bucketName string, attrs storage.BucketAttrsToUpdate) error {
+	if _, err := sc.StorageClient.Bucket(bucketName).Update(sc.Ctx, attrs); err != nil {
+		return daisy.Errf("Error updating bucket `%v` : %v", bucketName, err)
+	}
+	return nil
+}
+
 // Buckets returns a bucket iterator for all buckets within a project
 func (sc *Client) Buckets(projectID string) *storage.BucketIterator {
 	return sc.StorageClient.Buckets(sc.Ctx, projectID)

--- a/cli_tools/mocks/mock_storage_client.go
+++ b/cli_tools/mocks/mock_storage_client.go
@@ -23,8 +23,9 @@ import (
 	reflect "reflect"
 
 	storage "cloud.google.com/go/storage"
-	domain "github.com/GoogleCloudPlatform/compute-image-import/cli_tools/common/domain"
 	gomock "github.com/golang/mock/gomock"
+
+	domain "github.com/GoogleCloudPlatform/compute-image-import/cli_tools/common/domain"
 )
 
 // MockStorageClientInterface is a mock of StorageClientInterface interface.
@@ -90,6 +91,20 @@ func (m *MockStorageClientInterface) CreateBucket(arg0, arg1 string, arg2 *stora
 func (mr *MockStorageClientInterfaceMockRecorder) CreateBucket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockStorageClientInterface)(nil).CreateBucket), arg0, arg1, arg2)
+}
+
+// CreateBucket mocks base method.
+func (m *MockStorageClientInterface) UpdateBucket(arg0 string, arg1 storage.BucketAttrsToUpdate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBucket", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBucket indicates an expected call of UpdateBucket.
+func (mr *MockStorageClientInterfaceMockRecorder) UpdateBucket(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBucket", reflect.TypeOf((*MockStorageClientInterface)(nil).UpdateBucket), arg0, arg1)
 }
 
 // DeleteGcsPath mocks base method.


### PR DESCRIPTION
…55)" (#156)

This time avoid updating the bucket if the retention policy is already set to avoid contention resulting in 503 (internal) and 429 (quota reached) error from GCS.