### PR TITLE
Remove build for Debian 10 worker

### DIFF
--- a/debian_worker_cloudbuild.yaml
+++ b/debian_worker_cloudbuild.yaml
@@ -29,20 +29,6 @@ substitutions:
   _DAISY_DOCKER_TAG: 'latest'
 
 steps:
-# Build Debian 10 worker.
-- id: 'build-debian-10-worker'
-  name: 'gcr.io/compute-image-tools/daisy:${_DAISY_DOCKER_TAG}'
-  args: [
-        '-gcs_path=${_GCS_PATH}',
-        '-project=${_BUILDER_PROJECT}',
-        '-var:commit_sha=$COMMIT_SHA',
-        '-var:family_tag=debian-10-worker',
-        '-var:image_prefix=debian-10-worker',
-        '-var:image_project=${_IMAGE_PROJECT}',
-        '-var:source_image=projects/debian-cloud/global/images/family/debian-10',
-        '${_DAISY_WORKFLOW}'
-        ]
-
 # Build Debian 11 worker.
 - id: 'build-debian-11-worker'
   name: 'gcr.io/compute-image-tools/daisy:${_DAISY_DOCKER_TAG}'


### PR DESCRIPTION
The relevant image family is deprecated, and we can no longer build new images from it (projects/debian-cloud/global/images/family/debian-10)