### PR TITLE
Revert "Use Debian12 base containers in export flows (#161)"

### DIFF
--- a/gce_ovf_export.Dockerfile
+++ b/gce_ovf_export.Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM launcher.gcr.io/google/debian12
+FROM launcher.gcr.io/google/debian11
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y qemu-utils gnupg ca-certificates curl
 
 # Install gcsfuse, installed using instructions from:
 # https://cloud.google.com/storage/docs/gcsfuse-install
-ENV GCSFUSE_REPO=gcsfuse-bookworm
+ENV GCSFUSE_REPO=gcsfuse-bullseye
 RUN echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" > /etc/apt/sources.list.d/gcsfuse.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -q -y gcsfuse

--- a/gce_vm_image_export.Dockerfile
+++ b/gce_vm_image_export.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM launcher.gcr.io/google/debian12
+FROM gcr.io/distroless/base
 
 COPY linux/gce_vm_image_export /gce_vm_image_export
 COPY daisy_workflows/ /daisy_workflows/


### PR DESCRIPTION
This reverts commit 87b41fa6e27fc251f527e5dc51bc14636b010f38.

This change solved no vulnerabilities, reverting it to reduce risk during upcoming rollout