### PR TITLE
Revert gcs bucket update

### DIFF
--- a/cli_tools/common/domain/interfaces.go
+++ b/cli_tools/common/domain/interfaces.go
@@ -25,7 +25,6 @@ import (
 // StorageClientInterface represents GCS storage client
 type StorageClientInterface interface {
 	CreateBucket(bucketName string, project string, attrs *storage.BucketAttrs) error
-	UpdateBucket(bucketName string, attrs storage.BucketAttrsToUpdate) error
 	Buckets(projectID string) *storage.BucketIterator
 	GetBucketAttrs(bucket string) (*storage.BucketAttrs, error)
 	GetBucket(bucket string) *storage.BucketHandle

--- a/cli_tools/common/domain/interfaces.go
+++ b/cli_tools/common/domain/interfaces.go
@@ -104,7 +104,6 @@ type ZoneValidatorInterface interface {
 type ScratchBucketCreatorInterface interface {
 	CreateScratchBucket(sourceFileFlag string, projectFlag string, fallbackZone string,
 		enableUniformBucketLevelAccess bool) (string, string, error)
-	RemoveSoftDeleteFromBucket(bucketAttrs *storage.BucketAttrs) error
 	IsBucketInProject(project string, bucketName string) bool
 }
 

--- a/cli_tools/common/utils/param/param_utils.go
+++ b/cli_tools/common/utils/param/param_utils.go
@@ -99,15 +99,9 @@ func populateScratchBucketGcsPath(scratchBucketGcsPath *string, zone string, mgc
 		}
 
 		scratchBucketAttrs, err := storageClient.GetBucketAttrs(scratchBucketName)
-		if err != nil {
-			return "", err
+		if err == nil {
+			scratchBucketRegion = scratchBucketAttrs.Location
 		}
-
-		if err := scratchBucketCreator.RemoveSoftDeleteFromBucket(scratchBucketAttrs); err != nil {
-			return "", err
-		}
-
-		scratchBucketRegion = scratchBucketAttrs.Location
 	}
 	return scratchBucketRegion, nil
 }

--- a/cli_tools/common/utils/param/populator_test.go
+++ b/cli_tools/common/utils/param/populator_test.go
@@ -50,10 +50,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenZoneCantBeRetrieved(
 	mockResourceLocationRetriever.EXPECT().GetZone("us-west2", project).Return("",
 		daisy.Errf("zone not found")).Times(1)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	bucketAttrs := &storage.BucketAttrs{Location: "us-west2"}
-	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(bucketAttrs, nil).Times(1)
-	mockScratchBucketCreator.EXPECT().RemoveSoftDeleteFromBucket(bucketAttrs).Return(nil).Times(1)
-
+	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: "us-west2"}, nil).Times(1)
 	mockNetworkResolver := newNoOpNetworkResolver(mockCtrl)
 	mockMachineSeriesDetector := newMockN2N1MachineSeriesDetector(mockCtrl)
 	err := NewPopulator(
@@ -87,9 +84,7 @@ func TestPopulator_PropagatesErrorFromNetworkResolver(t *testing.T) {
 	mockScratchBucketCreator.EXPECT().IsBucketInProject(project, "scratchbucket").Return(true)
 	mockResourceLocationRetriever := mocks.NewMockResourceLocationRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	bucketAttrs := &storage.BucketAttrs{Location: "us-west2"}
-	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(bucketAttrs, nil).Times(1)
-	mockScratchBucketCreator.EXPECT().RemoveSoftDeleteFromBucket(bucketAttrs).Return(nil).Times(1)
+	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: "us-west2"}, nil).Times(1)
 	mockNetworkResolver := mocks.NewMockNetworkResolver(mockCtrl)
 	mockNetworkResolver.EXPECT().ResolveAndValidateNetworkAndSubnet("original-network", "original-subnet", "us-west2", "a_project").Return("", "", daisy.Errf("network cannot be found"))
 	mockMachineSeriesDetector := newMockN2N1MachineSeriesDetector(mockCtrl)
@@ -124,9 +119,7 @@ func TestPopulator_UsesReturnValuesFromNetworkResolver(t *testing.T) {
 	mockScratchBucketCreator.EXPECT().IsBucketInProject(project, "scratchbucket").Return(true)
 	mockResourceLocationRetriever := mocks.NewMockResourceLocationRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	bucketAttrs := &storage.BucketAttrs{Location: "us-west2"}
-	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(bucketAttrs, nil).Times(1)
-	mockScratchBucketCreator.EXPECT().RemoveSoftDeleteFromBucket(bucketAttrs).Return(nil).Times(1)
+	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: "us-west2"}, nil).Times(1)
 	mockNetworkResolver := mocks.NewMockNetworkResolver(mockCtrl)
 	mockNetworkResolver.EXPECT().ResolveAndValidateNetworkAndSubnet(
 		"original-network", "original-subnet", "us-west2", "a_project").Return("fixed-network", "fixed-subnet", nil)
@@ -330,10 +323,7 @@ func TestPopulator_PopulateMissingParametersReturnsErrorWhenPopulateRegionFails(
 	mockScratchBucketCreator.EXPECT().IsBucketInProject(project, "scratchbucket").Return(true)
 	mockResourceLocationRetriever := mocks.NewMockResourceLocationRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	bucketAttrs := &storage.BucketAttrs{Location: region}
-	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(bucketAttrs, nil).Times(1)
-	mockScratchBucketCreator.EXPECT().RemoveSoftDeleteFromBucket(bucketAttrs).Return(nil).Times(1)
-
+	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: region}, nil)
 	mockNetworkResolver := newNoOpNetworkResolver(mockCtrl)
 	mockMachineSeriesDetector := newMockN2N1MachineSeriesDetector(mockCtrl)
 	err := NewPopulator(
@@ -372,9 +362,7 @@ func TestPopulator_PopulateMissingParametersDoesNotChangeProvidedScratchBucketAn
 	mockResourceLocationRetriever := mocks.NewMockResourceLocationRetrieverInterface(mockCtrl)
 	mockResourceLocationRetriever.EXPECT().GetZone(expectedRegion, project).Return(expectedZone, nil).Times(1)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	bucketAttrs := &storage.BucketAttrs{Location: expectedRegion}
-	mockStorageClient.EXPECT().GetBucketAttrs(expectedBucketName).Return(bucketAttrs, nil).Times(1)
-	mockScratchBucketCreator.EXPECT().RemoveSoftDeleteFromBucket(bucketAttrs).Return(nil).Times(1)
+	mockStorageClient.EXPECT().GetBucketAttrs(expectedBucketName).Return(&storage.BucketAttrs{Location: expectedRegion}, nil)
 	mockNetworkResolver := newNoOpNetworkResolver(mockCtrl)
 	mockMachineSeriesDetector := newMockN2N1MachineSeriesDetector(mockCtrl)
 	err := NewPopulator(
@@ -607,9 +595,7 @@ func TestPopulator_PopulateMissingParametersPopulatesStorageLocationWithScratchB
 	mockScratchBucketCreator.EXPECT().IsBucketInProject(project, "scratchbucket").Return(true)
 	mockResourceLocationRetriever := mocks.NewMockResourceLocationRetrieverInterface(mockCtrl)
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-	bucketAttrs := &storage.BucketAttrs{Location: region}
-	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(bucketAttrs, nil).Times(1)
-	mockScratchBucketCreator.EXPECT().RemoveSoftDeleteFromBucket(bucketAttrs).Return(nil).Times(1)
+	mockStorageClient.EXPECT().GetBucketAttrs("scratchbucket").Return(&storage.BucketAttrs{Location: region}, nil)
 	mockResourceLocationRetriever.EXPECT().GetLargestStorageLocation(region).Return("US")
 	mockNetworkResolver := newNoOpNetworkResolver(mockCtrl)
 	mockMachineSeriesDetector := newMockN2N1MachineSeriesDetector(mockCtrl)

--- a/cli_tools/common/utils/storage/scratch_bucket_creator.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator.go
@@ -136,7 +136,7 @@ func (c *ScratchBucketCreator) createBucketIfNotExisting(project string,
 	}
 
 	if foundBucketAttrs != nil {
-		return foundBucketAttrs.Location, c.RemoveSoftDeleteFromBucket(foundBucketAttrs)
+		return foundBucketAttrs.Location, c.removeSoftDeleteFromBucket(foundBucketAttrs)
 
 	}
 
@@ -144,8 +144,7 @@ func (c *ScratchBucketCreator) createBucketIfNotExisting(project string,
 	return bucketAttrs.Location, c.StorageClient.CreateBucket(bucketAttrs.Name, project, bucketAttrs)
 }
 
-// RemoveSoftDeleteFromBucket removed the soft deletion protection from the given bucket.
-func (c *ScratchBucketCreator) RemoveSoftDeleteFromBucket(bucketAttrs *storage.BucketAttrs) error {
+func (c *ScratchBucketCreator) removeSoftDeleteFromBucket(bucketAttrs *storage.BucketAttrs) error {
 	if bucketAttrs.SoftDeletePolicy.RetentionDuration == 0 {
 		return nil
 	}

--- a/cli_tools/common/utils/storage/scratch_bucket_creator.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator.go
@@ -134,25 +134,14 @@ func (c *ScratchBucketCreator) createBucketIfNotExisting(project string,
 	if err != nil {
 		return "", err
 	}
-
 	if foundBucketAttrs != nil {
-		return foundBucketAttrs.Location, c.removeSoftDeleteFromBucket(foundBucketAttrs)
-
+		return foundBucketAttrs.Location, nil
 	}
-
 	log.Printf("Creating scratch bucket `%v` in %v region", bucketAttrs.Name, bucketAttrs.Location)
-	return bucketAttrs.Location, c.StorageClient.CreateBucket(bucketAttrs.Name, project, bucketAttrs)
-}
-
-func (c *ScratchBucketCreator) removeSoftDeleteFromBucket(bucketAttrs *storage.BucketAttrs) error {
-	if bucketAttrs.SoftDeletePolicy.RetentionDuration == 0 {
-		return nil
+	if err := c.StorageClient.CreateBucket(bucketAttrs.Name, project, bucketAttrs); err != nil {
+		return "", err
 	}
-	log.Printf("Updating soft delete property of scratch bucket `%v` in %v region", bucketAttrs.Name, bucketAttrs.Location)
-	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
-		SoftDeletePolicy: &storage.SoftDeletePolicy{RetentionDuration: 0},
-	}
-	return c.StorageClient.UpdateBucket(bucketAttrs.Name, bucketAttrsToUpdate)
+	return bucketAttrs.Location, nil
 }
 
 // IsBucketInProject checks if bucket belongs to a project

--- a/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator_test.go
@@ -19,15 +19,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/compute-image-import/cli_tools/common/domain"
+	"github.com/GoogleCloudPlatform/compute-image-import/cli_tools/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/iterator"
-
-	"github.com/GoogleCloudPlatform/compute-image-import/cli_tools/common/domain"
-	"github.com/GoogleCloudPlatform/compute-image-import/cli_tools/mocks"
 )
 
 func TestCreateScratchBucketErrorWhenProjectNotProvided(t *testing.T) {
@@ -175,6 +173,7 @@ func TestCreateScratchBucketNewBucketCreatedProject(t *testing.T) {
 	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
 	mockStorageClient.EXPECT().GetBucketAttrs(sourceBucketAttrs.Name).Return(sourceBucketAttrs, nil).Times(1)
 	mockStorageClient.EXPECT().CreateBucket("project1-daisy-bkt-us-west2", project, scratchBucketAttrs).Return(nil).Times(1)
+
 	mockBucketIterator := mocks.NewMockBucketIteratorInterface(mockCtrl)
 	first := mockBucketIterator.EXPECT().Next().Return(anotherBucketAttrs, nil)
 	second := mockBucketIterator.EXPECT().Next().Return(sourceBucketAttrs, nil)
@@ -323,20 +322,6 @@ func TestCreateScratchBucketReturnsExistingScratchBucketNoCreate(t *testing.T) {
 	defer mockCtrl.Finish()
 	ctx := context.Background()
 
-	tests := []struct {
-		name string
-
-		retentionDurationMilliSeconds int64
-	}{
-		{
-			name: "NoSoftDeletion",
-		},
-		{
-			name:                          "NoSoftDeletion",
-			retentionDurationMilliSeconds: 18,
-		},
-	}
-
 	projectID := "PROJECT1"
 
 	sourceBucketAttrs := &storage.BucketAttrs{
@@ -350,48 +335,32 @@ func TestCreateScratchBucketReturnsExistingScratchBucketNoCreate(t *testing.T) {
 		StorageClass: "regional",
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			scratchBucketAttrs := &storage.BucketAttrs{
-				Name:             "project1-daisy-bkt-us-west2",
-				Location:         "us-west2",
-				StorageClass:     "regional",
-				SoftDeletePolicy: &storage.SoftDeletePolicy{RetentionDuration: time.Duration(tc.retentionDurationMilliSeconds)},
-			}
-
-			mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
-			mockStorageClient.EXPECT().GetBucketAttrs("sourcebucket").Return(sourceBucketAttrs, nil).Times(1)
-
-			mockBucketIterator := mocks.NewMockBucketIteratorInterface(mockCtrl)
-			first := mockBucketIterator.EXPECT().Next().Return(anotherBucketAttrs, nil)
-			second := mockBucketIterator.EXPECT().Next().Return(sourceBucketAttrs, nil)
-			third := mockBucketIterator.EXPECT().Next().Return(scratchBucketAttrs, nil)
-
-			gomock.InOrder(first, second, third)
-
-			mockBucketIteratorCreator := mocks.NewMockBucketIteratorCreatorInterface(mockCtrl)
-			mockBucketIteratorCreator.EXPECT().
-				CreateBucketIterator(ctx, mockStorageClient, projectID).
-				Return(mockBucketIterator).
-				Times(1)
-
-			updateCount := 0
-			if tc.retentionDurationMilliSeconds > 0 {
-				updateCount = 1
-			}
-
-			mockStorageClient.EXPECT().UpdateBucket("project1-daisy-bkt-us-west2", storage.BucketAttrsToUpdate{
-				SoftDeletePolicy: &storage.SoftDeletePolicy{RetentionDuration: 0},
-			}).Return(nil).Times(updateCount)
-
-			c := ScratchBucketCreator{mockStorageClient, ctx, mockBucketIteratorCreator}
-			bucket, region, err := c.CreateScratchBucket("gs://sourcebucket/sourcefile", projectID, "", true)
-			assert.Equal(t, "project1-daisy-bkt-us-west2", bucket)
-			assert.Equal(t, "us-west2", region)
-			assert.Nil(t, err)
-		})
+	scratchBucketAttrs := &storage.BucketAttrs{
+		Name:         "project1-daisy-bkt-us-west2",
+		Location:     "us-west2",
+		StorageClass: "regional",
 	}
+	mockStorageClient := mocks.NewMockStorageClientInterface(mockCtrl)
+	mockStorageClient.EXPECT().GetBucketAttrs("sourcebucket").Return(sourceBucketAttrs, nil).Times(1)
 
+	mockBucketIterator := mocks.NewMockBucketIteratorInterface(mockCtrl)
+	first := mockBucketIterator.EXPECT().Next().Return(anotherBucketAttrs, nil)
+	second := mockBucketIterator.EXPECT().Next().Return(sourceBucketAttrs, nil)
+	third := mockBucketIterator.EXPECT().Next().Return(scratchBucketAttrs, nil)
+
+	gomock.InOrder(first, second, third)
+
+	mockBucketIteratorCreator := mocks.NewMockBucketIteratorCreatorInterface(mockCtrl)
+	mockBucketIteratorCreator.EXPECT().
+		CreateBucketIterator(ctx, mockStorageClient, projectID).
+		Return(mockBucketIterator).
+		Times(1)
+
+	c := ScratchBucketCreator{mockStorageClient, ctx, mockBucketIteratorCreator}
+	bucket, region, err := c.CreateScratchBucket("gs://sourcebucket/sourcefile", projectID, "", true)
+	assert.Equal(t, "project1-daisy-bkt-us-west2", bucket)
+	assert.Equal(t, "us-west2", region)
+	assert.Nil(t, err)
 }
 
 func TestCreateScratchBucketErrorWhenCreatingBucket(t *testing.T) {

--- a/cli_tools/common/utils/storage/storage_client.go
+++ b/cli_tools/common/utils/storage/storage_client.go
@@ -73,15 +73,6 @@ func (sc *Client) CreateBucket(
 	return nil
 }
 
-// UpdateBucket updates a GCS bucket
-func (sc *Client) UpdateBucket(
-	bucketName string, attrs storage.BucketAttrsToUpdate) error {
-	if _, err := sc.StorageClient.Bucket(bucketName).Update(sc.Ctx, attrs); err != nil {
-		return daisy.Errf("Error updating bucket `%v` : %v", bucketName, err)
-	}
-	return nil
-}
-
 // Buckets returns a bucket iterator for all buckets within a project
 func (sc *Client) Buckets(projectID string) *storage.BucketIterator {
 	return sc.StorageClient.Buckets(sc.Ctx, projectID)

--- a/cli_tools/mocks/mock_scratch_bucket_creator.go
+++ b/cli_tools/mocks/mock_scratch_bucket_creator.go
@@ -19,10 +19,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
-	"cloud.google.com/go/storage"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockScratchBucketCreatorInterface is a mock of ScratchBucketCreatorInterface interface.
@@ -62,24 +60,6 @@ func (m *MockScratchBucketCreatorInterface) CreateScratchBucket(arg0, arg1, arg2
 func (mr *MockScratchBucketCreatorInterfaceMockRecorder) CreateScratchBucket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateScratchBucket", reflect.TypeOf((*MockScratchBucketCreatorInterface)(nil).CreateScratchBucket), arg0, arg1, arg2, arg3)
-}
-
-// RemoveSoftDeleteFromBucket removed the soft deletion protection from the given bucket.
-// CreateScratchBucket mocks base method.
-func (m *MockScratchBucketCreatorInterface) RemoveSoftDeleteFromBucket(arg *storage.BucketAttrs) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSoftDeleteFromBucket", arg)
-	var err error
-	if ret[0] != nil {
-		err = ret[0].(error)
-	}
-	return err
-}
-
-// CreateScratchBucket indicates an expected call of CreateScratchBucket.
-func (mr *MockScratchBucketCreatorInterfaceMockRecorder) RemoveSoftDeleteFromBucket(arg interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSoftDeleteFromBucket", reflect.TypeOf((*MockScratchBucketCreatorInterface)(nil).RemoveSoftDeleteFromBucket), arg)
 }
 
 // IsBucketInProject mocks base method.

--- a/cli_tools/mocks/mock_storage_client.go
+++ b/cli_tools/mocks/mock_storage_client.go
@@ -23,9 +23,8 @@ import (
 	reflect "reflect"
 
 	storage "cloud.google.com/go/storage"
-	gomock "github.com/golang/mock/gomock"
-
 	domain "github.com/GoogleCloudPlatform/compute-image-import/cli_tools/common/domain"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockStorageClientInterface is a mock of StorageClientInterface interface.
@@ -91,20 +90,6 @@ func (m *MockStorageClientInterface) CreateBucket(arg0, arg1 string, arg2 *stora
 func (mr *MockStorageClientInterfaceMockRecorder) CreateBucket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockStorageClientInterface)(nil).CreateBucket), arg0, arg1, arg2)
-}
-
-// CreateBucket mocks base method.
-func (m *MockStorageClientInterface) UpdateBucket(arg0 string, arg1 storage.BucketAttrsToUpdate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBucket", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateBucket indicates an expected call of UpdateBucket.
-func (mr *MockStorageClientInterfaceMockRecorder) UpdateBucket(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBucket", reflect.TypeOf((*MockStorageClientInterface)(nil).UpdateBucket), arg0, arg1)
 }
 
 // DeleteGcsPath mocks base method.


### PR DESCRIPTION
This might be risky.
In case customers are using the scratch bucket to store their own data and rely on the soft deletion policy.
