### PR TITLE
export: Fetch devices by IDs

### DIFF
--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -10,19 +10,20 @@ INTERVAL=10
 
 # Prepare parameters for resizing
 ZONE=$(curl "${METADATA_URL}/zone" -H "Metadata-Flavor: Google"| cut -d'/' -f4)
+BUFFER_DEVICE=$(readlink -f /dev/disk/by-id/google-disk-export-disk-buffer*)
 BUFFER_DISK=$(curl "${METADATA_URL}/attributes/buffer-disk" -H "Metadata-Flavor: Google")
 
 echo "Max disk size ${MAX_SIZE}GB, min buffer size ${BUFFER_SIZE}GB, starting monitoring available disk buffer every ${INTERVAL}s..."
 while sleep ${INTERVAL}; do
   # Check whether available buffer space is lower than threshold.
-  AVAILABLE_BUFFER=$(df -BG /dev/sdc --output=avail | sed -n 2p)
+  AVAILABLE_BUFFER=$(df -BG ${BUFFER_DEVICE} --output=avail | sed -n 2p)
   AVAILABLE_BUFFER=${AVAILABLE_BUFFER%?}
   if [[ ${AVAILABLE_BUFFER} -ge ${BUFFER_MIN_SIZE} ]]; then
     continue
   fi
 
   # Decide the new size of the device.
-  CURRENT_DEVICE_SIZE_BYTES=$(lsblk /dev/sdc --output=size -b | sed -n 2p)
+  CURRENT_DEVICE_SIZE_BYTES=$(lsblk ${BUFFER_DEVICE} --output=size -b | sed -n 2p)
   CURRENT_DEVICE_SIZE=$(awk "BEGIN {print int(((${CURRENT_DEVICE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
   NEXT_SIZE=$(awk "BEGIN {print int(${CURRENT_DEVICE_SIZE} + ${BUFFER_SIZE})}")
 
@@ -32,7 +33,7 @@ while sleep ${INTERVAL}; do
     continue
   fi
   echo ${out}
-  if ! out=$(sudo resize2fs /dev/sdc 2>&1); then
+  if ! out=$(sudo resize2fs ${BUFFER_DEVICE} 2>&1); then
     echo "ExportFailed: Failed to resize partition of buffer disk. [Privacy-> Error: ${out} <-Privacy]"
     continue
   fi
@@ -41,7 +42,7 @@ while sleep ${INTERVAL}; do
   # If current file system has reached or exceeded max size, then stop resizing.
   # We need to know the size of the available file system other than the size of
   # the partition, so "df" is used instead of "lsblk" here.
-  CURRENT_FILESYSTEM_SIZE=$(df -BG /dev/sdc --output=size | sed -n 2p)
+  CURRENT_FILESYSTEM_SIZE=$(df -BG ${BUFFER_DEVICE} --output=size | sed -n 2p)
   CURRENT_FILESYSTEM_SIZE=${CURRENT_FILESYSTEM_SIZE%?}
   if [[ ${CURRENT_FILESYSTEM_SIZE} -ge ${MAX_SIZE} ]]; then
     echo "Buffer disk reaches max size."

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -31,16 +31,17 @@ LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
 
 mkdir ~/upload
 
+SOURCE_DEVICE=$(readlink -f /dev/disk/by-id/google-disk-image-export-ext)
 # Source disk size info.
-SOURCE_SIZE_BYTES=$(lsblk /dev/sdb --output=size -b | sed -n 2p)
+SOURCE_SIZE_BYTES=$(lsblk $SOURCE_DEVICE --output=size -b | sed -n 2p)
 SOURCE_SIZE_GB=$(awk "BEGIN {print int(((${SOURCE_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
 serialOutputPrefixedKeyValue "GCEExport" "source-size-gb" "${SOURCE_SIZE_GB}"
 
 echo "GCEExport: Running export tool."
 if [[ -n $LICENSES ]]; then
-  gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -licenses "$LICENSES" -y
+  gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk "$SOURCE_DEVICE" -licenses "$LICENSES" -y
 else
-  gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk /dev/sdb -y
+  gce_export -buffer_prefix ~/upload -gcs_path "$GCS_PATH" -disk "$SOURCE_DEVICE" -y
 fi
 GCE_EXPORT_RESULT=$?
 if [[ ${GCE_EXPORT_RESULT} -eq 2 ]]; then


### PR DESCRIPTION
Prior to this change hard-coded device names were used. This caused issues when working with debian-12-worker image, since the device wasn't given a peristent name.