### PR TITLE
export: Use the MD server IP directly

### DIFF
--- a/daisy_workflows/export/disk_resizing_mon.sh
+++ b/daisy_workflows/export/disk_resizing_mon.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BYTES_1GB=1073741824
-METADATA_URL="http://metadata/computeMetadata/v1/instance"
+METADATA_URL="http:/169.254.169.254/computeMetadata/v1/instance"
 
 MAX_SIZE=$1
 BUFFER_MIN_SIZE=10

--- a/daisy_workflows/export/export_disk.sh
+++ b/daisy_workflows/export/export_disk.sh
@@ -25,7 +25,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 BYTES_1GB=1073741824
-URL="http://metadata/computeMetadata/v1/instance/attributes"
+URL="http://169.254.169.254/computeMetadata/v1/instance/attributes"
 GCS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 LICENSES=$(curl -f -H Metadata-Flavor:Google ${URL}/licenses)
 

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -26,7 +26,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 BYTES_1GB=1073741824
-URL="http://metadata/computeMetadata/v1/instance/attributes"
+URL="http://169.254.169.254/computeMetadata/v1/instance/attributes"
 GS_PATH=$(curl -f -H Metadata-Flavor:Google ${URL}/gcs-path)
 FORMAT=$(curl -f -H Metadata-Flavor:Google ${URL}/format)
 DISK_RESIZING_MON=$(curl -f -H Metadata-Flavor:Google ${URL}/resizing-script-name)


### PR DESCRIPTION
This is meant to make the flow more resiliant to DNS failures.

It's done only in export flows, since import flows are deprecated and M2VM should be used instead.