### PR TITLE
Added no_external_ip flag to gce vm image export tool

### DIFF
--- a/cli_tools/common/utils/logging/service/log_entry.go
+++ b/cli_tools/common/utils/logging/service/log_entry.go
@@ -123,6 +123,7 @@ type ImageExportParams struct {
 	Format                string `json:"format,omitempty"`
 	ComputeServiceAccount string `json:"compute_service_account,omitempty"`
 	SourceDiskSnapshot    string `json:"source_disk_snapshot,omitempty"`
+	NoExternalIP          bool   `json:"no_external_ip,omitempty"`
 }
 
 // OnestepImageImportParams contains all input params for onestep image import

--- a/cli_tools/gce_vm_image_export/README.md
+++ b/cli_tools/gce_vm_image_export/README.md
@@ -48,6 +48,8 @@ Exactly one of these must be specified:
 + `-disable_gcs_logging` Do not stream logs to GCS
 + `-disable_cloud_logging` Do not stream logs to Cloud Logging
 + `-disable_stdout_logging` Do not display individual workflow logs on stdout
++ `-no_external_ip` Temporary VMs are created in your project during image export.
+  Set this flag so that these temporary VMs are not assigned external IP addresses.
 + `-labels=[KEY=VALUE,...]` labels: List of label KEY=VALUE pairs to add. Keys must start with a
   lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and 
   numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.
@@ -63,6 +65,6 @@ gce_vm_image_export -destination_uri=DESTINATION_URI [-client_id=CLIENT_ID]
         [-format=FORMAT] [-project=PROJECT] [-network=NETWORK]
         [-subnet=SUBNET] [-zone=ZONE] [-timeout=TIMEOUT] [-scratch_bucket_gcs_path=PATH]
         [-oauth=OAUTH_PATH] [-compute_endpoint_override=ENDPOINT] [-disable_gcs_logging]
-        [-disable_cloud_logging] [-disable_stdout_logging] [-labels=KEY=VALUE,...]
+        [-disable_cloud_logging] [-disable_stdout_logging] [-no_external_ip] [-labels=KEY=VALUE,...]
         [-compute_service_account=COMPUTE_SERVICE_ACCOUNT] [-client_version]
 ```

--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -79,6 +79,7 @@ type ImageExportRequest struct {
 	CurrentExecutablePath       string
 	NestedVirtualizationEnabled bool
 	WorkerMachineSeries         []string
+	NoExternalIP                bool
 }
 
 func validateAndParseFlags(destinationURI string, sourceImage string, sourceDiskSnapshot string, labels string) (map[string]string, error) {
@@ -237,6 +238,7 @@ func Run(logger logging.Logger, args *ImageExportRequest) error {
 		ExecutionID:                 os.Getenv(os.Getenv(daisyutils.BuildIDOSEnvVarName)),
 		WorkerMachineSeries:         args.WorkerMachineSeries,
 		NestedVirtualizationEnabled: args.NestedVirtualizationEnabled,
+		NoExternalIP:                args.NoExternalIP,
 		Tool: daisyutils.Tool{
 			HumanReadableName: "gce image export",
 			ResourceLabelName: "gce-image-export",

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -47,6 +47,7 @@ var (
 	cloudLogsDisabled           = flag.Bool("disable_cloud_logging", false, "do not stream logs to Cloud Logging.")
 	stdoutLogsDisabled          = flag.Bool("disable_stdout_logging", false, "do not display individual workflow logs on stdout.")
 	labels                      = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
+	noExternalIP                = flag.Bool("no_external_ip", false, "Temporary VMs are created in your project during image export. Set this flag so that these temporary VMs are not assigned external IP addresses.")
 	nestedVirtualizationEnabled = flag.Bool("enable_nested_virtualization", true, "When enabled, temporary worker VMs will be created with enabled nested virtualization. See https://cloud.google.com/compute/docs/instances/nested-virtualization/enabling for details.")
 	workerMachineSeries         flags.StringArrayFlag
 )
@@ -82,6 +83,7 @@ func exportEntry() (service.Loggable, error) {
 		CurrentExecutablePath:       currentExecutablePath,
 		WorkerMachineSeries:         *&workerMachineSeries,
 		NestedVirtualizationEnabled: *nestedVirtualizationEnabled,
+		NoExternalIP:                 *noExternalIP,
 	}
 
 	err := exporter.Run(logger, args)
@@ -115,6 +117,7 @@ func main() {
 			Format:                *format,
 			ComputeServiceAccount: *computeServiceAccount,
 			SourceDiskSnapshot:    *sourceDiskSnapshot,
+			NoExternalIP:           *noExternalIP,
 		},
 	}
 

--- a/cli_tools/gce_vm_image_export/main.go
+++ b/cli_tools/gce_vm_image_export/main.go
@@ -83,7 +83,7 @@ func exportEntry() (service.Loggable, error) {
 		CurrentExecutablePath:       currentExecutablePath,
 		WorkerMachineSeries:         *&workerMachineSeries,
 		NestedVirtualizationEnabled: *nestedVirtualizationEnabled,
-		NoExternalIP:                 *noExternalIP,
+		NoExternalIP:                *noExternalIP,
 	}
 
 	err := exporter.Run(logger, args)
@@ -117,7 +117,7 @@ func main() {
 			Format:                *format,
 			ComputeServiceAccount: *computeServiceAccount,
 			SourceDiskSnapshot:    *sourceDiskSnapshot,
-			NoExternalIP:           *noExternalIP,
+			NoExternalIP:          *noExternalIP,
 		},
 	}
 


### PR DESCRIPTION
This PR implements the no_external_ip flag in the gce_vm_image_export tool. 

It has been tested using a build pushed to [docker hub](https://hub.docker.com/repository/docker/oladapoajala/gce_vm_image_export/general).