### PR TITLE
fix: remove unregistered PyPI packages from Daisy workflow install_requires

### DIFF
--- a/daisy_workflows/image_import/inspection/setup.py
+++ b/daisy_workflows/image_import/inspection/setup.py
@@ -19,9 +19,10 @@ setup(
   name="boot_inspect",
   version="0.1",
   package_dir={"": "src"},
-  install_requires=[
-    'compute_image_tools_proto',
-  ],
+  # compute_image_tools_proto is an internal package not published to PyPI.
+  # Install it locally before installing this package:
+  #   pip install -e ../../../proto/py
+  install_requires=[],
   packages=find_namespace_packages(where="src"),
   entry_points={
     "console_scripts": [

--- a/daisy_workflows/image_import/suse/suse_import/setup.py
+++ b/daisy_workflows/image_import/suse/suse_import/setup.py
@@ -19,9 +19,10 @@ setup(
     name="suse_import",
     version="0.1",
     packages=["on_demand"],
-    install_requires=[
-        "linux_common",
-    ],
+    # linux_common is an internal package not published to PyPI.
+    # Install it locally before installing this package:
+    #   pip install -e ../../../../linux_common
+    install_requires=[],
     py_modules=["translate"],
     package_data={
         "on_demand": ["*.sh"],


### PR DESCRIPTION
`linux_common` and `compute_image_tools_proto` are declared in `install_requires` in two Daisy workflow `setup.py` files but are not registered on PyPI. When a developer or CI pipeline runs `pip install -e .` in either directory, pip queries PyPI for these names. An attacker who registers `linux-common` or `compute-image-tools-proto` at any version will have their package installed in place of the intended internal library — in the workflows that drive Compute Engine VM image import and boot inspection.

This PR removes the unregistered names from `install_requires` and documents the correct local installation path, eliminating the PyPI lookup.
