### PR TITLE
Improve tar.gz disk export performance:

### DIFF
--- a/cli_tools/gce_vm_image_export/exporter/exporter.go
+++ b/cli_tools/gce_vm_image_export/exporter/exporter.go
@@ -41,8 +41,9 @@ import (
 
 // Make file paths mutable
 var (
-	WorkflowDir    = "daisy_workflows/export/"
-	ExportWorkflow = "image_export_ext.wf.json"
+	WorkflowDir       = "daisy_workflows/export/"
+	ExportWorkflow    = "image_export_ext.wf.json"
+	ExportTarWorkflow = "image_export_ext_tar.wf.json"
 )
 
 // Parameter key shared with external packages
@@ -102,12 +103,16 @@ func validateAndParseFlags(destinationURI string, sourceImage string, sourceDisk
 	return nil, nil
 }
 
-func getWorkflowPath(currentExecutablePath string) string {
+func getWorkflowPath(format string, currentExecutablePath string) string {
+	workflow := ExportWorkflow
+	if format == "tar.gz" {
+		workflow = ExportTarWorkflow
+	}
 	if basePath := os.Getenv("WORKFLOW_BASE_PATH"); basePath != "" {
-		return filepath.Join(basePath, ExportWorkflow)
+		return filepath.Join(basePath, workflow)
 	}
 
-	return path.ToWorkingDir(WorkflowDir+ExportWorkflow, currentExecutablePath)
+	return path.ToWorkingDir(WorkflowDir+workflow, currentExecutablePath)
 }
 
 func buildDaisyVars(destinationURI string, sourceImage string, sourceDiskSnapshot string, imageDiskSizeGb int64, format string, network string,
@@ -135,7 +140,7 @@ func buildDaisyVars(destinationURI string, sourceImage string, sourceDiskSnapsho
 		varMap["source_disk_snapshot"] = param.GetGlobalResourcePath("snapshots", sourceDiskSnapshot)
 	}
 
-	if imageDiskSizeGb > 0 {
+	if imageDiskSizeGb > 0 && format != "tar.gz" {
 		// We want the size to allow for a 2 step (dd and tar) packaging of the image.
 		// In addition, we want to allow for some overhead (5%) in case of completely random data.
 		bufferDiskSizeGb := int64(math.Ceil(float64(imageDiskSizeGb) * 2.05))
@@ -218,7 +223,7 @@ func Run(logger logging.Logger, args *ImageExportRequest) error {
 		args.Format, args.Network, args.Subnet, *region, args.ComputeServiceAccount)
 
 	workflowProvider := func() (*daisy.Workflow, error) {
-		return daisy.NewFromFile(getWorkflowPath(args.CurrentExecutablePath))
+		return daisy.NewFromFile(getWorkflowPath(args.Format, args.CurrentExecutablePath))
 	}
 
 	env := daisyutils.EnvironmentSettings{

--- a/daisy_workflows/export/disk_export_ext_tar.wf.json
+++ b/daisy_workflows/export/disk_export_ext_tar.wf.json
@@ -1,0 +1,124 @@
+{
+  "Name": "disk-export-ext",
+  "DefaultTimeout": "90m",
+  "Vars": {
+    "source_disk": {
+      "Required": true,
+      "Description": "disk to export"
+    },
+    "destination": {
+      "Required": true,
+      "Description": "GCS path to export image to"
+    },
+    "format": {
+      "Required": true,
+      "Description": "Format to export disk as"
+    },
+    "export_instance_disk_image": {
+      "Value": "projects/cos-cloud/global/images/family/cos-stable",
+      "Description": "image to use for the exporter instance"
+    },
+    "export_instance_disk_type": {
+      "Value": "pd-ssd",
+      "Description": "Disk type of the OS disk. By default it's pd-ssd for higher speed."
+    },
+    "export_network": {
+      "Value": "global/networks/default",
+      "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
+    },
+    "compute_service_account": {
+      "Value": "default",
+      "Description": "Service account that will be used by the created worker instance"
+    },
+    "export_disk_ext.sh": {
+      "Value": "./export_disk_ext_tar.sh",
+      "Description": "Path to export_disk_ext.sh script"
+    }
+  },
+  "Sources": {
+    "${NAME}_export_disk_ext.sh": "${export_disk_ext.sh}"
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-${NAME}-os",
+          "SourceImage": "${export_instance_disk_image}",
+          "Type": "${export_instance_disk_type}"
+        }
+      ]
+    },
+    "run-${NAME}": {
+      "CreateInstances": [
+        {
+          "Name": "inst-${NAME}",
+          "Disks": [
+            {"Source": "disk-${NAME}-os"},
+            {"Source": "${source_disk}", "Mode": "READ_ONLY"}
+          ],
+          "MachineType": "n1-highcpu-4",
+          "Metadata": {
+            "block-project-ssh-keys": "true",
+            "gcs-path": "${OUTSPATH}/${NAME}",
+            "format": "${format}",
+            "startup-script": "${SOURCE:${NAME}_export_disk_ext.sh}"
+          },
+          "networkInterfaces": [
+            {
+              "network": "${export_network}",
+              "subnetwork": "${export_subnet}"
+            }
+          ],
+          "RetryWhenExternalIPDenied": true,
+          "ServiceAccounts": [
+            {
+              "Email": "${compute_service_account}",
+              "Scopes": [
+                "https://www.googleapis.com/auth/devstorage.full_control",
+                "https://www.googleapis.com/auth/compute"
+                ]
+            }
+          ],
+          "AutoDelete": true
+        }
+      ]
+    },
+    "wait-for-inst-${NAME}": {
+      "WaitForInstancesSignal": [
+        {
+          "Name": "inst-${NAME}",
+          "SerialOutput": {
+            "Port": 1,
+            "SuccessMatch": "export success",
+            "FailureMatch": "ExportFailed:",
+            "StatusMatch": "GCEExport:"
+          }
+        }
+      ]
+    },
+    "delete-inst": {
+      "DeleteResources": {
+        "Instances": ["inst-${NAME}"],
+        "Disks": ["disk-${NAME}-os"]
+      }
+    },
+    "copy-image-object": {
+      "CopyGCSObjects": [
+        {
+          "Source": "${OUTSPATH}/${NAME}",
+          "Destination": "${destination}"
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "run-${NAME}": ["setup-disks"],
+    "wait-for-inst-${NAME}": ["run-${NAME}"],
+    "delete-inst": ["wait-for-inst-${NAME}"],
+    "copy-image-object": ["wait-for-inst-${NAME}"]
+  }
+}

--- a/daisy_workflows/export/export_disk_ext.sh
+++ b/daisy_workflows/export/export_disk_ext.sh
@@ -139,34 +139,20 @@ echo "GCEExport: Launching disk size monitor in background..."
 disk_resizing_monitor "${MAX_BUFFER_DISK_SIZE_GB}" &
 
 echo "GCEExport: Exporting disk of size ${SIZE_OUTPUT_GB}GB and format ${FORMAT}."
-# If format is tar.gz, dd the source device to a raw disk file and then tar it.
-# Otherwise, use docker to run qemu-img convert.
-if [[ "${FORMAT}" == "tar.gz" ]]; then
-  RAW_DISK_PATH="/var/gs/${OUTS_PATH}/disk.raw"
-  if ! out=$(dd if="${SOURCE_DEVICE}" of="${RAW_DISK_PATH}" bs=4M); then
-    echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GS_PATH} <-Privacy] due to dd error: [Privacy-> ${out} <-Privacy]"
-    exit
-  fi
-  if ! out=$(tar --create --format=gnu --owner=0 --group=0 --mode=0600 --gzip --file "/var/gs/${IMAGE_OUTPUT_PATH}" -C "/var/gs/${OUTS_PATH}" "disk.raw" 2>&1); then
-    echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GS_PATH} <-Privacy] due to tar error: [Privacy-> ${out} <-Privacy]"
-    exit
-  fi
-  echo "${out}"
-else
-  QEMU_IMG_DOCKER_IMAGE=$(curl -f -H Metadata-Flavor:Google ${ATTRIBUTES_URL}/qemu-img-docker-image)
-  echo "GCEExport: Pulling docker image ${QEMU_IMG_DOCKER_IMAGE}..."
-  if ! out=$(docker pull "${QEMU_IMG_DOCKER_IMAGE}" 2>&1); then
-    echo "ExportFailed: Failed to pull docker image [Privacy-> ${QEMU_IMG_DOCKER_IMAGE} <-Privacy]. Error: [Privacy-> ${out} <-Privacy]"
-    exit
-  fi
-  echo "${out}"
 
-  echo "GCEExport: Running qemu-img convert..."
-  docker run --rm -v /tmp:/t -e HOME=/root -v /var/gs:/var/gs --device="${SOURCE_DEVICE}":"${SOURCE_DEVICE}" --privileged "${QEMU_IMG_DOCKER_IMAGE}" /qemu-img convert "${SOURCE_DEVICE}" "/var/gs/${IMAGE_OUTPUT_PATH}" -p -O "${FORMAT}" 2> >(tee /var/gs/qemu_err.txt >&2)
-  if [[ $? -ne 0 ]]; then
-    echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GS_PATH} <-Privacy] due to qemu-img error: [Privacy-> $(</var/gs/qemu_err.txt) <-Privacy]"
-    exit
-  fi
+QEMU_IMG_DOCKER_IMAGE=$(curl -f -H Metadata-Flavor:Google ${ATTRIBUTES_URL}/qemu-img-docker-image)
+echo "GCEExport: Pulling docker image ${QEMU_IMG_DOCKER_IMAGE}..."
+if ! out=$(docker pull "${QEMU_IMG_DOCKER_IMAGE}" 2>&1); then
+  echo "ExportFailed: Failed to pull docker image [Privacy-> ${QEMU_IMG_DOCKER_IMAGE} <-Privacy]. Error: [Privacy-> ${out} <-Privacy]"
+  exit
+fi
+echo "${out}"
+
+echo "GCEExport: Running qemu-img convert..."
+docker run --rm -v /tmp:/t -e HOME=/root -v /var/gs:/var/gs --device="${SOURCE_DEVICE}":"${SOURCE_DEVICE}" --privileged "${QEMU_IMG_DOCKER_IMAGE}" /qemu-img convert "${SOURCE_DEVICE}" "/var/gs/${IMAGE_OUTPUT_PATH}" -p -O "${FORMAT}" 2> >(tee /var/gs/qemu_err.txt >&2)
+if [[ $? -ne 0 ]]; then
+  echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GS_PATH} <-Privacy] due to qemu-img error: [Privacy-> $(</var/gs/qemu_err.txt) <-Privacy]"
+  exit
 fi
 
 # Exported image size info.
@@ -182,6 +168,7 @@ if [[ $? -ne 0 ]] ; then
   echo "ExportFailed: Failed to copy output image to GCS [Privacy-> ${GS_PATH}, error: $(</var/gs/gcloud_err.txt) <-Privacy]"
   exit
 fi
+
 # TODO(b/460360483): Change the success/failure signal as sometimes the last
 # lines are not printed. Use another signal - https://github.com/GoogleCloudPlatform/compute-daisy/blob/master/step_wait_for_instances_signal.go#L81.
 echo "export success"

--- a/daisy_workflows/export/export_disk_ext_tar.sh
+++ b/daisy_workflows/export/export_disk_ext_tar.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -x
+
+function serialOutputPrefixedKeyValue() {
+  stdbuf -oL echo "$1: <serial-output key:'$2' value:'$3'>"
+}
+
+GCLOUD_CLI_IMAGE="gcr.io/google.com/cloudsdktool/google-cloud-cli:545.0.0-slim"
+
+# Verify VM has access to Google APIs
+curl --silent --fail "https://www.googleapis.com/discovery/v1/apis" &> /dev/null;
+if [[ $? -ne 0 ]]; then
+  echo "ExportFailed: Cannot access Google APIs. Ensure that VPC settings allow VMs to access Google APIs either via external IP or Private Google Access. More info at: https://cloud.google.com/vpc/docs/configure-private-google-access"
+  exit
+fi
+
+BYTES_1GB=1073741824
+METADATA_URL="http://169.254.169.254/computeMetadata/v1/instance"
+ATTRIBUTES_URL="${METADATA_URL}/attributes"
+GS_PATH=$(curl -f -H Metadata-Flavor:Google ${ATTRIBUTES_URL}/gcs-path)
+FORMAT=$(curl -f -H Metadata-Flavor:Google ${ATTRIBUTES_URL}/format)
+
+# Strip gs:// prefix.
+IMAGE_OUTPUT_PATH=${GS_PATH##*//}
+# Create dir for output.
+OUTS_PATH=${IMAGE_OUTPUT_PATH%/*}
+mkdir -p "/var/gs/${OUTS_PATH}"
+
+# Prepare disk size info.
+# 1. Disk image size info.
+SOURCE_DEVICE=$(readlink -f /dev/disk/by-id/google-disk-image-export-ext)
+SIZE_BYTES=$(lsblk "${SOURCE_DEVICE}" --output=size -b | sed -n 2p)
+# 2. Round up to the next GB.
+SIZE_OUTPUT_GB=$(awk "BEGIN {print int(((${SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
+
+set +x
+serialOutputPrefixedKeyValue "GCEExport" "source-size-gb" "${SIZE_OUTPUT_GB}"
+set -x
+
+# Configure Docker to use the pre-installed docker-credential-gcr helper.
+# This command will write the configuration to $DOCKER_CONFIG/config.json.
+# The helper uses the VM's service account credentials from the metadata server.
+# Log in to GCR using the fetched token.
+# We need to set the HOME environment variable to /var/gs as COS the FS is read-only.
+export HOME=/var/gs
+if ! out=$(/usr/bin/docker-credential-gcr configure-docker); then
+  echo "ExportFailed: Failed to configure docker. [Privacy-> Error: ${out} <-Privacy]"
+  exit
+fi
+
+echo "GCEExport: Pulling docker image ${GCLOUD_CLI_IMAGE}..."
+if ! out=$(docker pull "${GCLOUD_CLI_IMAGE}" 2>&1); then
+  echo "ExportFailed: Failed to pull docker image [Privacy-> ${GCLOUD_CLI_IMAGE} <-Privacy]. Error: [Privacy-> ${out} <-Privacy]"
+  exit
+fi
+echo "${out}"
+
+echo "GCEExport: Exporting disk of size ${SIZE_OUTPUT_GB}GB and format ${FORMAT}."
+
+PART_FILES=()
+function cleanup() {
+  if [[ "${#PART_FILES[@]}" -eq 0 ]]; then
+    return
+  fi
+  echo "GCEExport: Cleaning up part files: ${PART_FILES[*]}"
+  if docker run --rm "${GCLOUD_CLI_IMAGE}" gcloud storage rm "${PART_FILES[@]}"; then
+    PART_FILES=()
+  else
+    echo "ExportWarning: Failed to remove files: ${PART_FILES[*]}"
+  fi
+}
+trap cleanup EXIT
+
+cd "/var/gs"
+
+# 1. Create empty disk.raw file of right size. This is just used to create the correct tar header.
+if ! truncate -s "${SIZE_BYTES}" disk.raw; then
+  echo "ExportFailed: Failed to create empty disk.raw file."
+  exit
+fi
+
+# 2. Steal the 512-byte header, forcing GNU format to ensure even large tars have a single 512-byte header.
+if ! tar --create --format=gnu --owner=0 --group=0 --mode=0600 --file - disk.raw | head -c 512 > header.bin; then
+  echo "ExportFailed: Failed to create tar header."
+  exit
+fi
+rm disk.raw
+
+# 3. Calculate alignment padding + 1024 bytes for the Tar EOF marker
+REMAINDER=$(( SIZE_BYTES % 512 ))
+PAD_BYTES=$(( REMAINDER == 0 ? 0 : 512 - REMAINDER ))
+TOTAL_TRAILER_BYTES=$(( PAD_BYTES + 1024 ))
+
+# 4. Split into chunks and stream them separately for performance
+# GZIPs can be concatated together into a single valid GZIP file, and doing so has minimal impact on compression.
+
+CPU_COUNT=$(nproc)
+if [[ $CPU_COUNT -gt 8 ]]; then
+  CPU_COUNT=8 # limit to reduce risk of hitting OOMs.
+fi
+
+for (( i=0; i<CPU_COUNT; i++ )); do
+  PART_FILES+=("${GS_PATH}.part${i}")
+done
+
+CHUNK_SIZE=$(( SIZE_BYTES / CPU_COUNT ))
+
+echo "GCEExport: TOTAL_TRAILER_BYTES: ${TOTAL_TRAILER_BYTES}, CPU_COUNT: ${CPU_COUNT}, CHUNK_SIZE: ${CHUNK_SIZE}"
+
+PIDS=()
+for (( i=0; i<CPU_COUNT; i++ )); do
+  (
+    set -eo pipefail
+    SKIP_BYTES=$(( i * CHUNK_SIZE ))
+    COUNT_BYTES=$CHUNK_SIZE
+    if [[ $i -eq $(( CPU_COUNT - 1 )) ]]; then
+      COUNT_BYTES=$(( SIZE_BYTES - SKIP_BYTES ))
+    fi
+
+    echo "GCEExport chunk ${i}: SKIP_BYTES: ${SKIP_BYTES}, COUNT_BYTES: ${COUNT_BYTES}"
+
+    (
+      # Stream header for the first chunk.
+      if [[ $i -eq 0 ]]; then
+        cat header.bin
+      fi
+
+      # Stream the chunk.
+      dd if="${SOURCE_DEVICE}" bs=4M skip="${SKIP_BYTES}" count="${COUNT_BYTES}" iflag=skip_bytes,count_bytes
+
+      # Stream the trailer for the last chunk.
+      if [[ $i -eq $(( CPU_COUNT - 1 )) ]]; then
+        head -c "${TOTAL_TRAILER_BYTES}" /dev/zero
+      fi
+    ) | gzip -3 -c | docker run -i --rm "${GCLOUD_CLI_IMAGE}" gcloud storage cp --quiet - "${GS_PATH}.part${i}"
+  ) &
+  PIDS+=($!)
+done
+
+(
+  while sleep 100; do
+    for (( i=0; i<CPU_COUNT; i++ )); do
+      SKIP_BYTES=$(( i * CHUNK_SIZE ))
+      if DD_PID=$(pgrep -f "dd if=${SOURCE_DEVICE}.*skip=${SKIP_BYTES} "); then
+        echo "--- Progress for chunk ${i} ---"
+        # Send SIGUSR1 to the dd process to print progress to stderr.
+        kill -USR1 "$DD_PID"
+        # Sleep so that progress from different chunks don't overlap.
+        sleep 5
+      fi
+    done
+  done
+) &
+MONITOR_PID=$!
+
+FAIL=0
+for pid in "${PIDS[@]}"; do
+  wait "$pid" || FAIL=1
+done
+
+kill "$MONITOR_PID"
+
+if [[ $FAIL -ne 0 ]]; then
+  echo "ExportFailed: Failed to export disk source to GCS [Privacy-> ${GS_PATH} <-Privacy] via native streaming tar.gz"
+  exit
+fi
+
+if ! docker run --rm "${GCLOUD_CLI_IMAGE}" gcloud storage objects compose "${PART_FILES[@]}" "${GS_PATH}"; then
+  echo "ExportFailed: Failed to compose parts into ${GS_PATH}"
+  exit
+fi
+
+cleanup
+
+rm header.bin
+
+# Exported image size info.
+TARGET_SIZE_BYTES=$(docker run --rm "${GCLOUD_CLI_IMAGE}" gcloud storage du -s "${GS_PATH}" | awk '{print $1}')
+TARGET_SIZE_GB=$(awk "BEGIN {print int(((${TARGET_SIZE_BYTES}-1)/${BYTES_1GB}) + 1)}")
+set +x
+serialOutputPrefixedKeyValue "GCEExport" "target-size-gb" "${TARGET_SIZE_GB}"
+set -x
+
+# TODO(b/460360483): Change the success/failure signal as sometimes the last
+# lines are not printed. Use another signal - https://github.com/GoogleCloudPlatform/compute-daisy/blob/master/step_wait_for_instances_signal.go#L81.
+echo "export success"
+sleep 5
+echo "export success"
+sleep 5
+echo "export success"
+
+sync

--- a/daisy_workflows/export/image_export_ext_tar.wf.json
+++ b/daisy_workflows/export/image_export_ext_tar.wf.json
@@ -1,0 +1,76 @@
+{
+  "Name": "image-export-ext",
+  "DefaultTimeout": "90m",
+  "Vars": {
+    "source_image": {
+      "Description": "URL of the image to export"
+    },
+    "source_disk_snapshot": {
+      "Description": "URL of the disk snapshot to export"
+    },
+    "destination": {
+      "Required": true,
+      "Description": "GCS path to export image to"
+    },
+    "format": {
+      "Required": true,
+      "Description": "Format to export image as"
+    },
+    "export_instance_disk_image": {
+      "Value": "projects/cos-cloud/global/images/family/cos-stable",
+      "Description": "image to use for the exporter instance"
+    },
+    "export_instance_disk_type": {
+      "Value": "pd-ssd",
+      "Description": "Disk type of the OS disk. By default it's pd-ssd for higher speed."
+    },
+    "export_network": {
+      "Value": "global/networks/default",
+      "Description": "Network to use for the export instance"
+    },
+    "export_subnet": {
+      "Value": "",
+      "Description": "SubNetwork to use for the export instance"
+    },
+    "compute_service_account": {
+      "Value": "default",
+      "Description": "Service account that will be used by the created worker instance"
+    }
+  },
+  "Steps": {
+    "setup-disks": {
+      "CreateDisks": [
+        {
+          "Name": "disk-${NAME}",
+          "SourceImage": "${source_image}",
+          "SourceSnapshot": "${source_disk_snapshot}",
+          "Type": "${export_instance_disk_type}"
+        }
+      ]
+    },
+    "export-disk": {
+      "IncludeWorkflow": {
+        "Path": "./disk_export_ext_tar.wf.json",
+        "Vars": {
+          "source_disk": "disk-${NAME}",
+          "destination": "${destination}",
+          "format": "${format}",
+          "export_instance_disk_image": "${export_instance_disk_image}",
+          "export_instance_disk_type": "${export_instance_disk_type}",
+          "export_network": "${export_network}",
+          "export_subnet": "${export_subnet}",
+          "compute_service_account": "${compute_service_account}"
+        }
+      }
+    },
+    "delete-disks": {
+      "DeleteResources": {
+        "Disks": ["disk-${NAME}"]
+      }
+    }
+  },
+  "Dependencies": {
+    "export-disk": ["setup-disks"],
+    "delete-disks": ["export-disk"]
+  }
+}


### PR DESCRIPTION
1. Avoid writing intermediate disk file and tar.gz to disk by streaming straight to GCS. 
1a. To do so, create tar semi-manually since tar command doesn't work on disks, only files.
2. Parallelize gzipping by chunking tar and gzipping each separately. Gzips can be directly concatanated to make a bigger gzip.
3. Parallelize uploads for each chunk, then call compose to create a single object.
4. Remove attached disk used for storing intermediate outputs.
4a. Remove disk monitor used to resize the intermediate outputs disk.